### PR TITLE
Optionally use longtable for LaTeX tables.

### DIFF
--- a/bin/table_classification_summaries_others
+++ b/bin/table_classification_summaries_others
@@ -69,9 +69,9 @@ def create_cli_parser():
     parser.add_argument('--num-splits', '-s', action='store',
                         type=int, help='Number of horizontal splits.',
                         default=1)
-    parser.add_argument('--with-preamble', action='store_true',
-                        dest='with_preamble', default=False,
-                        help='Write out a whole LaTeX article (not just the table).')
+    parser.add_argument('--without-preamble', action='store_true',
+                        dest='without_preamble', default=False,
+                        help='Write out only the table (for inclusion in a separate document).')
     return parser
 
 
@@ -79,10 +79,12 @@ if __name__ == '__main__':
     parser = create_cli_parser()
     options = parser.parse_args()
     classifier, data_dcts = parse_krun_file_with_changepoints(options.json_files[0])
-    if options.with_preamble:
-        print 'Writing out full document, with preamble.'
+    if options.without_preamble:
+        print('Writing out only the LaTeX table, output file will need a preamble '
+              'in order to compile correctly.')
     summary_data = collect_summary_statistics(data_dcts, classifier['delta'], classifier['steady'])
     machine, bmarks, latex_summary = convert_to_latex(summary_data, classifier['delta'], classifier['steady'])
-    print 'Writing data to:', options.latex_file
+    print('Writing data to: %s' % options.latex_file)
     write_latex_table(machine, bmarks, latex_summary, options.latex_file,
-                      options.num_splits, options.with_preamble)
+                      options.num_splits, with_preamble=(not options.without_preamble),
+                      longtable=True)

--- a/bin/warmup_stats
+++ b/bin/warmup_stats
@@ -305,7 +305,7 @@ def main(options):
         if len(latex_summary.keys()) > 1:  # More than one VM.
             num_splits = 2
         write_latex_table(machine, bmarks, latex_summary, options.output_latex,
-                          num_splits, with_preamble=True)
+                          num_splits, longtable=True, with_preamble=True)
         info('Compiling table as PDF.')
         cli = [pdflatex_path, '-interaction=batchmode', options.output_latex]
         debug('Running: %s' % ' '.join(cli))

--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -207,9 +207,34 @@ __LATEX_START_TABLE = lambda format_, headings: """
 \\midrule
 """ % (format_, headings)
 
+__LATEX_START_LONGTABLE = lambda format_, headings: """
+{
+\\setlength\\sparkspikewidth{1.5pt}
+\\definecolor{sparkbottomlinecolor}{gray}{0.8}
+%% Older versions of sparklines do not expose bottomlinethickness
+\\renewcommand{\\sparkbottomline}[1][1]{\\pgfsetlinewidth{0.2pt}%%
+  \\color{sparkbottomlinecolor}%%
+  \\pgfline{\\pgfxy(0,0)}{\\pgfxy(#1,0)}\\color{sparklinecolor}}
+
+\\begin{longtable}{%s}
+%s \\\\
+\\hline
+\\endfirsthead
+%s \\\\
+\\hline
+\\endhead
+\\hline
+""" % (format_, headings, headings)
+
 __LATEX_END_TABLE = """
 \\bottomrule
 \\end{tabular}
+}
+"""
+
+__LATEX_END_LONGTABLE = """
+\\hline
+\\end{longtable}
 }
 """
 
@@ -224,6 +249,10 @@ def end_document():
 
 def end_table():
     return __LATEX_END_TABLE
+
+
+def end_longtable():
+    return __LATEX_END_LONGTABLE
 
 
 def escape(word):
@@ -307,3 +336,6 @@ def section(heading):
 
 def start_table(format_, headings):
     return __LATEX_START_TABLE(format_, headings)
+
+def start_longtable(format_, headings):
+    return __LATEX_START_LONGTABLE(format_, headings)


### PR DESCRIPTION
LaTeX output before this PR: [long_before.pdf](https://github.com/softdevteam/warmup_stats/files/1376385/long_before.pdf)

and after: [long_after.pdf](https://github.com/softdevteam/warmup_stats/files/1376396/long_after.pdf)
