### PR TITLE
Check for (some) packages needed for installation to complete.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,23 @@
 #! /bin/sh
 
+which git > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "git must be installed" >&2
+    exit 1
+fi
+
+which python2.7 > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "python2.7 must be installed" >&2
+    exit 1
+fi
+
+python2.7 -c "import setuptools" > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "setuptools for python2.7 must be installed" >&2
+    exit 1
+fi
+
 set -e
 
 HERE_DIR=$(dirname $(readlink -f "$0"))


### PR DESCRIPTION
This is certainly not a complete list, but I noticed earlier that if these things are missing, then installation fails in weird or silent fashion (e.g. it appears to continue successfully, but doesn't install things, and scrolling back through the terminal one eventually spots the source of the error). It would be good to think more carefully about what other things are needed, but this is a
start at least.