### PR TITLE
More windows/WSL fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+work/
+warmup/*.pyc
+warmup/__pycache__/
+

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ export LD_LIBRARY_PATH="${R_INST_DIR}/lib/R/lib:${LD_LIBRARY_PATH}"
 # Install R changepoint package.
 echo "install.packages('devtools', lib='${R_INST_DIR}/lib/R/library', repos='http://cran.us.r-project.org')" | R_LIBS_USER=${R_INST_DIR}/lib/R/library/ ${R_INST_DIR}/bin/R --no-save
 echo "install.packages('MultinomialCI', lib='${R_INST_DIR}/lib/R/library', repos='http://cran.us.r-project.org')" | R_LIBS_USER=${R_INST_DIR}/lib/R/library/ ${R_INST_DIR}/bin/R --no-save
-echo "options(download.file.method = \"wget\"); devtools::install_github('rkillick/changepoint')" | R_LIBS_USER=${R_INST_DIR}/lib/R/library/ ${R_INST_DIR}/bin/R --no-save
+echo "devtools::install_git('git://github.com/rkillick/changepoint', branch = 'master')" | R_LIBS_USER=${R_INST_DIR}/lib/R/library/ ${R_INST_DIR}/bin/R --no-save
 
 # Install rpy2 Python package.
 DEB8_HACK=0


### PR DESCRIPTION
Switch to using devtools::install_git instead of devtools::install_github for the changepoint r module.
Added a gitignore for all compiled python filed generated and the work directories contents