### PR TITLE
Correctly space table headings.

### DIFF
--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -217,13 +217,10 @@ __LATEX_START_LONGTABLE = lambda format_, headings: """
   \\pgfline{\\pgfxy(0,0)}{\\pgfxy(#1,0)}\\color{sparklinecolor}}
 
 \\begin{longtable}{%s}
-%s \\\\
-\\hline
+%s \\\\\\hline
 \\endfirsthead
-%s \\\\
-\\hline
+%s \\\\\\hline
 \\endhead
-\\hline
 """ % (format_, headings, headings)
 
 __LATEX_END_TABLE = """


### PR DESCRIPTION
This fixes a bug where table headings appeared in the wrong place, with a duplicate horizontal rule beneath them.

Example (note, both pages of the PDF are important here!):

**Before:** [before_table_before.pdf](https://github.com/softdevteam/warmup_stats/files/1644483/before_table_before.pdf)

**After:** [before_table_after.pdf](https://github.com/softdevteam/warmup_stats/files/1644484/before_table_after.pdf)

Fixes #15 