### PR TITLE
Diff Krun results files

### DIFF
--- a/bin/diff_results
+++ b/bin/diff_results
@@ -1,0 +1,520 @@
+#!/usr/bin/python2.7
+
+# Copyright (c) 2017 King's College London
+# created by the Software Development Team <http://soft-dev.org/>
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or
+# data (collectively the "Software"), free of charge and under any and all
+# copyright rights in the Software, and any and all patent rights owned or
+# freely licensable by each licensor hereunder covering either (i) the
+# unmodified Software as contributed to or provided by such licensor, or (ii)
+# the Larger Works (as defined below), to deal in both
+#
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software (each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition: The above copyright
+# notice and either this complete permission notice or at a minimum a reference
+# to the UPL must be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Plot a chart describing the effect of re-running an experiment with fewer iterations.
+MUST be run after generate_truncated_json.
+"""
+
+import math
+import os
+import sys
+
+if ('LD_LIBRARY_PATH' not in os.environ or 'R-inst' not in os.environ['LD_LIBRARY_PATH']
+      or 'R_HOME' not in os.environ):
+    # R packages are stored relative to the top-level of the repo.
+    os.environ['R_HOME'] = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                                        'work', 'R-inst', 'lib', 'R')
+    os.environ['LD_LIBRARY_PATH'] = ':'.join([os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                                              'work', 'R-inst', 'lib', 'R', 'lib'), os.environ.get('LD_LIBRARY_PATH', '')])
+    args = [sys.executable]
+    args.extend(sys.argv)
+    os.execv(sys.executable, args)
+
+# We use a custom install of rpy2, relative to the top-level of the repo.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                                'work', 'pylibs'))
+
+import argparse
+import json
+import numpy
+
+import rpy2
+import rpy2.interactive.packages
+import rpy2.robjects
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from warmup.krun_results import parse_krun_file_with_changepoints
+from warmup.latex import end_document, end_longtable, end_table, escape
+from warmup.latex import get_latex_symbol_map, preamble
+from warmup.latex import start_longtable, start_table, STYLE_SYMBOLS
+from warmup.summary_statistics import BLANK_CELL, collect_summary_statistics
+from warmup.summary_statistics import convert_to_latex
+
+ALPHA = 0.01  # Significance level.
+CATEGORIES = ['warmup', 'slowdown', 'flat', 'no steady state']
+MCI = rpy2.interactive.packages.importr('MultinomialCI')
+# List indices (used in favour of dictionary keys).
+CLASSIFICATIONS = 0  # Indices for top-level summary lists.
+STEADY_ITER = 1
+STEADY_STATE_TIME = 2
+INTERSECTION = 3
+SAME = 0  # Indices for nested lists.
+DIFFERENT = 1
+BETTER = 2
+WORSE = 3
+# Dictionary keys
+BEFORE = 'before'
+AFTER = 'after'
+CLASSIFIER = 'classifier'
+DIFF = 'diff'
+# LaTeX output.
+TITLE = 'Summary of benchmark classifications'
+TABLE_FORMAT = 'll@{\hspace{0cm}}ll@{\hspace{-1cm}}r@{\hspace{0cm}}r@{\hspace{0cm}}r@{\hspace{0cm}}l@{\hspace{.3cm}}ll@{\hspace{-1cm}}r@{\hspace{0cm}}r@{\hspace{0cm}}r'
+TABLE_HEADINGS_START1 = '\\multicolumn{1}{c}{\\multirow{2}{*}{}}&'
+TABLE_HEADINGS_START2 = '&'
+TABLE_HEADINGS1 = '&&\\multicolumn{1}{c}{} &\\multicolumn{1}{c}{Steady}&\\multicolumn{1}{c}{Steady}&\\multicolumn{1}{c}{Steady}'
+TABLE_HEADINGS2 = '&&\\multicolumn{1}{c}{Class.} &\\multicolumn{1}{c}{iter (\#)} &\\multicolumn{1}{c}{iter (s)}&\\multicolumn{1}{c}{perf (s)}'
+
+JSON_VERSION_NUMBER = '2'
+
+
+def legend():
+    key = (colour_cell(BETTER, 'improved'), colour_cell(WORSE, 'worsened'),
+           colour_cell(DIFFERENT, 'different'), colour_cell(SAME, 'unchanged'))
+    return '\\textbf{Diff against previous results:} ' + ' '.join(key) + '.'
+
+
+def do_intervals_differ((x1, y1), (x2, y2)):
+    """Given two IQRs or CIs return True if they do NOT overlap."""
+
+    assert y1 >= x1 and y2 >= x2
+    return y1 < x2 or y2 < x1
+
+
+def do_mean_cis_differ(mean1, ci1, mean2, ci2):
+    """Given two means +/- CIs return True if they do NOT overlap."""
+
+    assert ci1 >= 0.0 and ci2 >= 0.0, 'Found negative confidence interval from bootstrapping.'
+    x1 = mean1 - ci1
+    y1 = mean1 + ci1
+    x2 = mean2 - ci2
+    y2 = mean2 + ci2
+    return do_intervals_differ((x1, y1), (x2, y2))
+
+
+def all_flat(classifications):
+    """Return True if all pexecs in a detailed classification dict are 'flat'."""
+
+    return (classifications['warmup'] == 0 and classifications['slowdown'] == 0
+            and classifications['no steady state'] == 0)
+
+
+def all_nss(classifications):
+    """Return True if all pexecs in a detailed classification dict are 'no steady state'."""
+
+    return (classifications['warmup'] == 0 and classifications['slowdown'] == 0 and
+            classifications['flat'] == 0)
+
+
+def any_nss(classifications):
+    """Return True if any pexec in a detailed classification dict is 'no steady state'."""
+
+    return classifications['no steady state'] > 0
+
+
+def diff(before_file, after_file, summary_filename):
+    """Diff results in before_file and after_file."""
+
+    classifiers = dict()
+    before_results = None
+    # In the JSON dump, we need the diff, and  the original summaries of the
+    # before / after results, so that they can be written into a LaTeX table.
+    summary = {DIFF: dict(), BEFORE: None, AFTER: None, CLASSIFIER: None}
+    print('Loading %s.' % before_file)
+    classifiers[BEFORE], before_results = parse_krun_file_with_changepoints([before_file])
+    summary[BEFORE] = collect_summary_statistics(before_results,
+                                                 classifiers[BEFORE]['delta'], classifiers[BEFORE]['steady'])
+    print('Loading %s.' % after_file)
+    classifiers[AFTER], after_results = parse_krun_file_with_changepoints([after_file])
+    summary[AFTER] = collect_summary_statistics(after_results,
+                                                classifiers[AFTER]['delta'], classifiers[AFTER]['steady'])
+    for key in classifiers[BEFORE]:
+        assert classifiers[BEFORE][key] == classifiers[AFTER][key], \
+            'Results files generated with different values for %s' % key
+    summary[CLASSIFIER] = classifiers[AFTER]
+    assert len(before_results.keys()) == 1, 'Expected one machine per results file.'
+    assert len(after_results.keys()) == 1, 'Expected one machine per results file.'
+    assert before_results.keys()[0] == after_results.keys()[0], 'Expected results to be from same machine.'
+    machine = before_results.keys()[0]
+    # Generate CIs for DEFAULT_ITER classification data.
+    before_class_cis = dict()
+    for key in before_results[machine]['classifications']:
+        if len(before_results[machine]['classifications'][key]) == 0:  # Skipped benchmark.
+            continue
+        class_counts = [before_results[machine]['classifications'][key].count(category) for category in CATEGORIES]
+        before_class_cis[key] = numpy.array(MCI.multinomialCI(rpy2.robjects.FloatVector(class_counts), ALPHA))
+    for key in after_results[machine]['classifications']:
+        if len(after_results[machine]['classifications'][key]) == 0:  # Skipped benchmark.
+            continue
+        if key in before_results[machine]['classifications']:
+            bench, vm = key.split(':')[:-1]
+            if vm not in summary[DIFF]:
+                summary[DIFF][vm] = dict()
+            summary[DIFF][vm][bench] = [None, None, None, None]
+    for key in after_results[machine]['classifications']:
+        if len(after_results[machine]['classifications'][key]) == 0:  # Skipped benchmark.
+            continue
+        if not key in before_results[machine]['classifications']:
+            continue
+        bench, vm = key.split(':')[:-1]
+        # Classifications are available, whether or not summary statistics can be generated.
+        trunc_cat = [summary[AFTER]['machines'][machine][vm][bench]['process_executons'][p]['classification'] \
+                     for p in xrange(len(summary[AFTER]['machines'][machine][vm][bench]['process_executons']))]
+        trunc_counts = [trunc_cat.count(category) for category in CATEGORIES]
+        after_class_cis = numpy.array(MCI.multinomialCI(rpy2.robjects.FloatVector(trunc_counts), ALPHA))
+        sample = summary[AFTER]['machines'][machine][vm][bench]
+        base_case = summary[BEFORE]['machines'][machine][vm][bench]
+        for category in CATEGORIES:
+            cat_index = CATEGORIES.index(category)
+            if do_intervals_differ(before_class_cis[key][cat_index], after_class_cis[cat_index]):
+                if (sample['detailed_classification']['no steady state'] < base_case['detailed_classification']['no steady state'] and
+                    sample['detailed_classification']['slowdown'] < base_case['detailed_classification']['slowdown']):
+                    summary[DIFF][vm][bench][CLASSIFICATIONS] = BETTER
+                    break
+                elif (sample['detailed_classification']['no steady state'] >= base_case['detailed_classification']['no steady state'] and
+                    sample['detailed_classification']['slowdown'] >= base_case['detailed_classification']['slowdown']):
+                    summary[DIFF][vm][bench][CLASSIFICATIONS] = WORSE
+                    break
+                else:
+                    summary[DIFF][vm][bench][CLASSIFICATIONS] = DIFFERENT
+                    break
+        else:
+            summary[DIFF][vm][bench][CLASSIFICATIONS] = SAME
+        # Case 1) All flat.
+        if (all_flat(sample['detailed_classification']) and all_flat(base_case['detailed_classification'])):
+            summary[DIFF][vm][bench][STEADY_ITER] = SAME
+            if base_case['steady_state_time_ci'] is None:
+                summary[DIFF][vm][bench][STEADY_STATE_TIME] = DIFFERENT
+            elif do_mean_cis_differ(base_case['steady_state_time'], base_case['steady_state_time_ci'],
+                                    sample['steady_state_time'], sample['steady_state_time_ci']):
+                if sample['steady_state_time'] < base_case['steady_state_time']:
+                    summary[DIFF][vm][bench][STEADY_STATE_TIME] = BETTER
+                else:
+                    summary[DIFF][vm][bench][STEADY_STATE_TIME] = WORSE
+            else:
+                summary[DIFF][vm][bench][STEADY_STATE_TIME] = SAME
+        # Case 2) One ALL FLAT, one not.
+        elif (all_flat(sample['detailed_classification']) or all_flat(base_case['detailed_classification'])):
+            if (any_nss(sample['detailed_classification']) or any_nss(base_case['detailed_classification'])):
+                summary[DIFF][vm][bench][STEADY_ITER] = DIFFERENT
+            elif (all_flat(base_case['detailed_classification']) and
+                  do_intervals_differ((1.0, 1.0), sample['steady_state_iteration_iqr'])):
+                if sample['steady_state_iteration'] < base_case['steady_state_iteration']:
+                    summary[DIFF][vm][bench][STEADY_ITER] = BETTER
+                else:
+                    summary[DIFF][vm][bench][STEADY_ITER] = WORSE
+            elif (all_flat(sample['detailed_classification']) and
+                  do_intervals_differ((1.0, 1.0), base_case['steady_state_iteration_iqr'])):
+                if sample['steady_state_iteration'] < base_case['steady_state_iteration']:
+                    summary[DIFF][vm][bench][STEADY_ITER] = BETTER
+                else:
+                    summary[DIFF][vm][bench][STEADY_ITER] = WORSE
+            else:
+                summary[DIFF][vm][bench][STEADY_ITER] = SAME
+            if (any_nss(sample['detailed_classification']) or any_nss(base_case['detailed_classification'])):
+                summary[DIFF][vm][bench][STEADY_STATE_TIME] = DIFFERENT
+            elif do_mean_cis_differ(base_case['steady_state_time'], base_case['steady_state_time_ci'],
+                                    sample['steady_state_time'], sample['steady_state_time_ci']):
+                if sample['steady_state_time'] < base_case['steady_state_time']:
+                    summary[DIFF][vm][bench][STEADY_STATE_TIME] = BETTER
+                else:
+                    summary[DIFF][vm][bench][STEADY_STATE_TIME] = WORSE
+            else:
+                summary[DIFF][vm][bench][STEADY_STATE_TIME] = SAME
+        # Case 3) One contains an NSS (therefore no steady iter / perf available).
+        elif (any_nss(sample['detailed_classification']) or
+              any_nss(base_case['detailed_classification'])):
+            pass
+        # Case 4) All three measures should be available in both the DEFAULT_ITER and last_iter cases.
+        else:
+            # If n_pexecs is small, and the steady_iters are all identical,
+            # we sometimes get odd IQRs like [7.000000000000001, 7.0], so
+            # deal with this as a special case to avoid triggering the assertion
+            # in do_intervals_differ.
+            if len(set(sample['steady_state_iteration_list'])) == 1:
+                fake_iqr = (float(sample['steady_state_iteration_list'][0]), float(sample['steady_state_iteration_list'][0]))
+                if do_intervals_differ(base_case['steady_state_iteration_iqr'], fake_iqr):
+                    if sample['steady_state_iteration'] < base_case['steady_state_iteration']:
+                        summary[DIFF][vm][bench][STEADY_ITER] = BETTER
+                    else:
+                        summary[DIFF][vm][bench][STEADY_ITER] = WORSE
+                else:
+                    summary[DIFF][vm][bench][STEADY_ITER] = SAME
+            elif do_intervals_differ(base_case['steady_state_iteration_iqr'],
+                                     sample['steady_state_iteration_iqr']):
+                if sample['steady_state_iteration'] < base_case['steady_state_iteration']:
+                    summary[DIFF][vm][bench][STEADY_ITER] = BETTER
+                else:
+                    summary[DIFF][vm][bench][STEADY_ITER] = WORSE
+            else:
+                summary[DIFF][vm][bench][STEADY_ITER] = SAME
+            if do_mean_cis_differ(base_case['steady_state_time'], base_case['steady_state_time_ci'],
+                                  sample['steady_state_time'], sample['steady_state_time_ci']):
+                if sample['steady_state_time'] < base_case['steady_state_time']:
+                    summary[DIFF][vm][bench][STEADY_STATE_TIME] = BETTER
+                else:
+                    summary[DIFF][vm][bench][STEADY_STATE_TIME] = WORSE
+            else:
+                summary[DIFF][vm][bench][STEADY_STATE_TIME] = SAME
+        # Was the benchmark better or worse overall?
+        if not (BETTER in summary[DIFF][vm][bench] or WORSE in summary[DIFF][vm][bench] or
+                DIFFERENT in summary[DIFF][vm][bench]):
+            summary[DIFF][vm][bench][INTERSECTION] = SAME
+        elif BETTER in summary[DIFF][vm][bench] and not WORSE in summary[DIFF][vm][bench]:
+            summary[DIFF][vm][bench][INTERSECTION] = BETTER
+        elif WORSE in summary[DIFF][vm][bench] and not BETTER in summary[DIFF][vm][bench]:
+            summary[DIFF][vm][bench][INTERSECTION] = WORSE
+        else:
+            summary[DIFF][vm][bench][INTERSECTION] = DIFFERENT
+    with open(summary_filename, 'w') as fd:
+        json.dump(summary, fd, ensure_ascii=True, indent=4)
+        print('Saved: %s' % summary_filename)
+    return summary
+
+
+def colour_cell(result, text):
+    """Colour a table cell containing `text` according to `result`."""
+
+    assert result in (None, SAME, DIFFERENT, BETTER, WORSE)
+    if not text or result is None or result == SAME:
+        return text
+    if result == BETTER:
+        colour = 'lightgreen'
+    elif result == WORSE:
+        colour = 'lightred'
+    else:
+        colour = 'lightyellow'
+    return '\\ccell{%s}{%s}' % (colour, text)
+
+
+def write_latex_table(machine, all_benchs, summary, diff, tex_file, num_splits,
+                      with_preamble=False, longtable=False):
+    """Write a tex table to disk"""
+
+    num_benchmarks = len(all_benchs)
+    all_vms = sorted(summary.keys())
+    num_vms = len(summary)
+
+    # decide how to lay out the splits
+    num_vms_rounded = int(math.ceil(num_vms / float(num_splits)) * num_splits)
+    vms_per_split = int(num_vms_rounded / float(num_splits))
+    splits = [[] for x in xrange(num_splits)]
+    vm_num = 0
+    split_idx = 0
+    for vm_idx in xrange(num_vms_rounded):
+        if vm_idx < len(all_vms):
+            vm = all_vms[vm_idx]
+        else:
+            vm = None
+        splits[split_idx].append(vm)
+        vm_num += 1
+        if vm_num % vms_per_split == 0:
+            split_idx += 1
+
+    with open(tex_file, 'w') as fp:
+        if with_preamble:
+            fp.write(preamble(TITLE))
+            legends = get_latex_symbol_map() + ' \\\\ ' + legend()
+            fp.write('\\centering %s' % legends)
+            fp.write('\n\n\n')
+            if not longtable:
+                fp.write('\\begin{landscape}\n')
+                fp.write('\\begin{table*}[hptb]\n')
+                fp.write('\\vspace{.8cm}\n')
+                fp.write('\\begin{adjustbox}{totalheight=12.4cm}\n')
+        # Emit table header.
+        heads1 = TABLE_HEADINGS_START1 + '&'.join([TABLE_HEADINGS1] * num_splits)
+        heads2 = TABLE_HEADINGS_START2 + '&'.join([TABLE_HEADINGS2] * num_splits)
+        heads = '%s\\\\%s' % (heads1, heads2)
+        if longtable:
+            fp.write(start_longtable(TABLE_FORMAT, heads))
+        else:
+            fp.write(start_table(TABLE_FORMAT, heads))
+        split_row_idx = 0
+        for row_vms in zip(*splits):
+            bench_idx = 0
+            for bench in sorted(all_benchs):
+                row = []
+                for vm in row_vms:
+                    if vm is None:
+                        continue # no more results
+                    try:
+                        this_summary = summary[vm][bench]
+                    except KeyError:
+                        last_cpt = BLANK_CELL
+                        time_steady = BLANK_CELL
+                        last_mean = BLANK_CELL
+                        classification = ''
+                    else:
+                        if vm in diff and bench in diff[vm]:
+                            classification = colour_cell(diff[vm][bench][CLASSIFICATIONS], this_summary['style'])
+                            last_cpt = colour_cell(diff[vm][bench][STEADY_ITER], this_summary['last_cpt'])
+                            time_steady = colour_cell(diff[vm][bench][STEADY_ITER], this_summary['time_to_steady_state'])
+                            last_mean = colour_cell(diff[vm][bench][STEADY_STATE_TIME], this_summary['last_mean'])
+                        else:
+                            classification = this_summary['style']
+                            last_cpt = this_summary['last_cpt']
+                            time_steady = this_summary['time_to_steady_state']
+                            last_mean = this_summary['last_mean']
+                        classification = '\\multicolumn{1}{l}{%s}' % classification
+                        if classification == STYLE_SYMBOLS['flat']:
+                            last_cpt = BLANK_CELL
+                            time_steady = BLANK_CELL
+                    if last_cpt == '':
+                        last_cpt = BLANK_CELL
+                    if time_steady == '':
+                        time_steady = BLANK_CELL
+                    if last_mean == '':
+                        last_mean = BLANK_CELL
+
+                    if bench_idx == 0:
+                        if num_benchmarks == 10:
+                            fudge = 4
+                        elif num_benchmarks == 12:
+                            fudge = 5
+                        else:
+                            fudge = 0
+                        vm_cell = '\\multirow{%s}{*}{\\rotatebox[origin=c]{90}{%s}}' \
+                            % (num_benchmarks + fudge, vm)
+                    else:
+                        vm_cell = ''
+                    row_add = [BLANK_CELL, vm_cell, classification, last_cpt,
+                               time_steady, last_mean]
+                    if not row:  # First bench in this row, needs the vm column.
+                        if vm in diff and bench in diff[vm]:
+                            bname = colour_cell(diff[vm][bench][INTERSECTION], bench)
+                        else:
+                            bname = bench
+                        row.insert(0, escape(bname))
+                    row.extend(row_add)
+                    vm_idx += 1
+                fp.write('&'.join(row))
+                # Only -ve space row if not next to a midrule
+                if bench_idx < num_vms - 1:
+                    fp.write('\\\\[-3pt] \n')
+                else:
+                    fp.write('\\\\ \n')
+                bench_idx += 1
+            if split_row_idx < vms_per_split - 1:
+                if longtable:
+                    fp.write('\\hline\n')
+                else:
+                    fp.write('\\midrule\n')
+            split_row_idx += 1
+        if longtable:
+            fp.write(end_longtable())
+        else:
+            fp.write(end_table())
+        if with_preamble:
+            if not longtable:
+                fp.write('\\end{adjustbox}\n')
+                fp.write('\\end{table*}\n')
+                fp.write('\\end{landscape}\n')
+            fp.write(end_document())
+
+
+def create_cli_parser():
+    """Create a parser to deal with command line switches."""
+
+    script = os.path.basename(__file__)
+    description = (('Diff two Krun results files. Input files to this script should '
+                    'already have outliers and changepoints marked (i.e. the '
+                    'mark_outliers_in_json and mark_changepoints_in_json scripts '
+                    'should already have been run).\n'
+                    '\n\nExample usage:\n\n'
+                    '\t$ python %s -f before.json.bz2 after.json.bz2 -o diff.tex\n'
+                    '\t$ python %s -s diff_summary.json -o diff.tex') % (script, script))
+    parser = argparse.ArgumentParser(description=description,
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('-o', '--output', action='store', default='diff_summary.tex',
+                        type=str, help='LaTeX file in which to write diff summary.')
+    parser.add_argument('-j', '--json', action='store', default='diff_summary.json',
+                        type=str, help='JSON file in which to write diff summary.')
+    parser.add_argument('--num-splits', '-n', action='store',
+                        type=int, help='Number of horizontal splits.',
+                        default=1)
+    parser.add_argument('--without-preamble', action='store_true',
+                        dest='without_preamble', default=False,
+                        help='Write out only the table (for inclusion in a separate document).')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-s', '--summary', action='store', default=None,
+                       type=str, help=('Read summary data from JSON file rather than '
+                                       'generating from a two original results files.'))
+    group.add_argument('-r', '--results-files', nargs=2, action='append', default=[], type=str,
+                       help='Exactly two Krun result files (with outliers and changepoints).')
+    return parser
+
+
+if __name__ == '__main__':
+    parser = create_cli_parser()
+    options = parser.parse_args()
+    diff_summary = None
+    if options.summary is None:
+        if '_outliers' not in options.results_files[0][0]:
+            print('Please run mark_outliers_in_json on file %s before diffing.' %
+                  options.results_files[0][0])
+            sys.exit(1)
+        if '_outliers' not in options.results_files[0][1]:
+            print ('Please run mark_outliers_in_json on file %s before diffing.' %
+                   options.results_files[0][1])
+            sys.exit(1)
+        if '_changepoints' not in options.results_files[0][0]:
+            print ('Please run mark_changepoints_in_json on file %s before diffing.' %
+                   options.results_files[0][0])
+            sys.exit(1)
+        if '_changepoints' not in options.results_files[0][1]:
+            print ('Please run mark_changepoints_in_json on file %s before diffing.' %
+                   options.results_files[0][1])
+            sys.exit(1)
+        diff_summary = diff(options.results_files[0][0], options.results_files[0][1], options.json)
+    else:
+        with open(options.summary, 'r') as fd:
+            diff_summary = json.load(fd)
+        if diff_summary is None:
+            print('Could not open %s.' % options.summary)
+            sys.exit(1)
+    classifier = diff_summary[CLASSIFIER]
+    machine, bmarks, latex_summary = convert_to_latex(diff_summary[AFTER], classifier['delta'],
+                                                      classifier['steady'], diff=diff_summary[DIFF],
+                                                      previous=diff_summary[BEFORE])
+    print('Writing data to: %s' % options.output)
+    write_latex_table(machine, bmarks, latex_summary, diff_summary[DIFF], options.output,
+                      options.num_splits, with_preamble=(not options.without_preamble),
+                      longtable=True)

--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -240,10 +240,8 @@ __LATEX_START_LONGTABLE = lambda format_, headings: """
 
 \\begin{longtable}{%s}
 %s \\\\\\hline
-\\endfirsthead
-%s \\\\\\hline
 \\endhead
-""" % (format_, headings, headings)
+""" % (format_, headings)
 
 __LATEX_END_TABLE = """
 \\bottomrule

--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -56,8 +56,6 @@ STYLE_SYMBOLS = {  # Requires \usepackage{amssymb} and \usepackage{sparklines}
 def get_latex_symbol_map(prefix='\\textbf{Symbol key:} '):
     symbols = list()
     for key in sorted(STYLE_SYMBOLS):
-        if key.startswith('mostly '):
-            continue
         symbols.append('%s~%s' % (STYLE_SYMBOLS[key], key.lower()))
     text  = prefix + ', '.join(symbols)
     text += '.'

--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -158,6 +158,28 @@ $\\begin{array}{rr}
        0.9 0.2
        /%
 \\end{sparkline}\\xspace}
+
+%
+% Coloured table cells.
+% https://tex.stackexchange.com/questions/360461/get-a-transparent-nestable-wrappable-background
+%
+\\makeatletter
+\\protected\\def\\ccell#1#{%
+  \\@ccell{#1}%
+}
+\\def\\@ccell#1#2#3{%
+   \\tcbox[tcbox raise base,left=0mm,right=0mm,top=0mm,bottom=0mm,%
+           boxsep=0.5pt,arc=0mm,boxrule=0pt,opacityfill=0.3,enhanced jigsaw,%
+           colback=#2!85!white,before=\\relax,after=\\relax]{#3}
+}
+\\makeatother
+
+%
+% Colours.
+%
+\\definecolor{lightred}{HTML}{e88a8a}
+\\definecolor{lightyellow}{HTML}{e8e58a}
+\\definecolor{lightgreen}{HTML}{8ae89c}
 """
 
 DEFAULT_DOCOPTS = '10pt, a4paper'
@@ -177,6 +199,8 @@ __LATEX_PREAMBLE = lambda title, doc_opts=DEFAULT_DOCOPTS: """
 \\usepackage{pdflscape}
 \\usepackage{rotating}
 \\usepackage{sparklines}
+\\usepackage{tcolorbox}
+\\tcbuselibrary{most}
 \\usepackage{xspace}
 
 
@@ -210,7 +234,7 @@ __LATEX_START_TABLE = lambda format_, headings: """
 __LATEX_START_LONGTABLE = lambda format_, headings: """
 {
 \\setlength\\sparkspikewidth{1.5pt}
-\\definecolor{sparkbottomlinecolor}{gray}{0.8}
+\\definecolor{sparkbottomlinecolor}{gray}{0.4}
 %% Older versions of sparklines do not expose bottomlinethickness
 \\renewcommand{\\sparkbottomline}[1][1]{\\pgfsetlinewidth{0.2pt}%%
   \\color{sparkbottomlinecolor}%%
@@ -285,7 +309,7 @@ def _histogram(data):
     return '\n'.join(sparkline)
 
 
-def format_median_error(median, error, data, one_dp=False, two_dp=False):
+def format_median_error(median, error, data, one_dp=False, two_dp=False, change=None):
     if one_dp:
         median_s = '%.1f' % median
         error_s = '(%.1f, %.1f)' % (error[0], error[1])
@@ -294,27 +318,55 @@ def format_median_error(median, error, data, one_dp=False, two_dp=False):
         error_s = '(%.3f, %.3f)' % (error[0], error[1])
     else:
         assert False
-    return """$
-\\begin{array}{r}
+    if change and one_dp:
+        change_s = '%+.1f' % change
+    elif change and two_dp:
+        change_s = '%+.3f' % change
+    if change:
+        tex = """$
+\\begin{array}{c}
+\\scriptstyle{%s} \\\\[-6pt]
+\\scriptscriptstyle{\\delta=%s} \\\\[-6pt]
+\\scriptscriptstyle{%s}
+\\end{array}
+$
+\\noindent\\parbox[p]{%s}{%s}
+"""  % (median_s, change_s, error_s, _SPARKLINE_WIDTH + 'ex', _histogram(data))
+    else:
+        tex = """$
+\\begin{array}{c}
 \\scriptstyle{%s} \\\\[-6pt]
 \\scriptscriptstyle{%s}
 \\end{array}
 $
 \\noindent\\parbox[p]{%s}{%s}
 """  % (median_s, error_s, _SPARKLINE_WIDTH + 'ex', _histogram(data))
+    return tex
 
 
-def format_median_ci(median, error, data):
+def format_median_ci(median, error, data, change=None):
     median_s = '%.5f' % median
     error_s = '%.6f' % error
-    return """$
-\\begin{array}{r}
+    if change:
+        tex = """$
+\\begin{array}{c}
+\\scriptstyle{%s} \\\\[-6pt]
+\\scriptscriptstyle{\\delta=%+.3f} \\\\[-6pt]
+\\scriptscriptstyle{\\pm%s}
+\\end{array}
+$
+\\noindent\\parbox[p]{%s}{%s}
+"""  % (median_s, change, error_s, _SPARKLINE_WIDTH + 'ex', _histogram(data))
+    else:
+        tex = """$
+\\begin{array}{c}
 \\scriptstyle{%s} \\\\[-6pt]
 \\scriptscriptstyle{\\pm%s}
 \\end{array}
 $
 \\noindent\\parbox[p]{%s}{%s}
 """  % (median_s, error_s, _SPARKLINE_WIDTH + 'ex', _histogram(data))
+    return tex
 
 
 def preamble(title, doc_opts=DEFAULT_DOCOPTS):


### PR DESCRIPTION
This PR adds a script which allows the user to diff two Krun results files, based on the algorithm that generated Figures 9 / 11 in the warmup paper.

The output is a LaTeX table, similar to the one produced by `table_classification_summaries_others`, which shows the results of the *second* input file, and some extra symbols showing which parts of the table have improved / worsened, etc. 

The symbol next to the benchmark name shows the 'intersection' of the other measures for that benchmark. Where NSS's appear in the summaries, we sometimes cannot compare before/after results, or sometimes we can only say that the two results differ.

The script dumps a human-readable JSON file with the results of the summary and the diff. This JSON file can then be read in by the script to produce a LaTeX file (rather than recomputing the diff and summaries directly from the Krun results files). This is probably less useful for end-users and more useful for debugging the script.

Also, the fix for Issue #15 turned out to have a bug in tables which only took up a single page. This PR contains a fix for that bug.

### CLI options

```
$ ./bin/diff_results --help
usage: diff_results [-h] [-o OUTPUT] [-j JSON] [--num-splits NUM_SPLITS]
                    [--without-preamble]
                    (-s SUMMARY | -r RESULTS_FILES RESULTS_FILES)

Diff two Krun results files. Input files to this script should already have outliers and changepoints marked (i.e. the mark_outliers_in_json and mark_changepoints_in_json scripts should already have been run).

Example usage:

	$ python diff_results -f before.json.bz2 after.json.bz2 -o diff.tex
	$ python diff_results -s diff_summary.json -o diff.tex

optional arguments:
  -h, --help            show this help message and exit
  -o OUTPUT, --output OUTPUT
                        LaTeX file in which to write diff summary.
  -j JSON, --json JSON  JSON file in which to write diff summary.
  --num-splits NUM_SPLITS, -n NUM_SPLITS
                        Number of horizontal splits.
  --without-preamble    Write out only the table (for inclusion in a separate document).
  -s SUMMARY, --summary SUMMARY
                        Read summary data from JSON file rather than generating from a two original results files.
  -r RESULTS_FILES RESULTS_FILES, --results-files RESULTS_FILES RESULTS_FILES
                        Exactly two Krun result files (with outliers and changepoints).
```

### Examples

**Before input data**: [before_table.pdf](https://github.com/softdevteam/warmup_stats/files/1644919/before_table.pdf)

**After1 input data**: [after_table.pdf](https://github.com/softdevteam/warmup_stats/files/1644920/after_table.pdf)

**After2 input data**: [after2_table.pdf](https://github.com/softdevteam/warmup_stats/files/1644922/after2_table.pdf)

**Diff Before -> After1**: [diff.pdf](https://github.com/softdevteam/warmup_stats/files/1644927/diff.pdf)

**Diff Before -> After2**: [diff2.pdf](https://github.com/softdevteam/warmup_stats/files/1644928/diff2.pdf)

Fixes #7 