### PR TITLE
Fix longtable headings.

### DIFF
--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -239,8 +239,7 @@ __LATEX_START_LONGTABLE = lambda format_, headings: """
   \\pgfline{\\pgfxy(0,0)}{\\pgfxy(#1,0)}\\color{sparklinecolor}}
 
 \\begin{longtable}{%s}
-%s \\\\
-\\hline
+%s \\\\\\hline
 \\endhead
 """ % (format_, headings)
 


### PR DESCRIPTION
Works in both "normal" and diff tables.

This seems like such an odd and brittle fix that I feel very uncomfortable about it. However, it works on the CSV files I tested with `--output-table` and `--output-diff`.

Fixes #15 