### PR TITLE
Html diff tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,20 @@ bin/warmup_stats  --output-plots plots.pdf --output-json summary.json -l javascr
 
 ## Creating tables
 
-The `--output-table <file.tex>` flag converts input data into a LaTeX / PDF
-table. Conversion to PDF requires `pdflatex` to be installed. `bin/warmup_stats`
-also needs the names of the language and VM under test, and the output of
-`uname -a` on the machine the benchmarks were run on. Example usage:
+The `--output-table <file>` flag converts input data into an HTML table or a
+LaTeX / PDF table. Conversion to PDF requires `pdflatex` to be installed.
+`bin/warmup_stats` also needs the names of the language and VM under test, and
+the output of `uname -a` on the machine the benchmarks were run on. Example
+usage (LaTeX / PDF):
 
 ```
-bin/warmup_stats  --output-table table.tex -l javascript -v V8 -u "`uname -a`" results.csv
+bin/warmup_stats --tex --output-table table.tex -l javascript -v V8 -u "`uname -a`" results.csv
+```
+
+Example usage (HTML):
+
+```
+bin/warmup_stats --html --output-table table.html -l javascript -v V8 -u "`uname -a`" results.csv
 ```
 
 
@@ -66,19 +73,25 @@ benchmark performance before and after a change is rarely simple. Users will
 want to produce a detailed comparison of the results in Krun results tables
 (above) in order to get a deeper insight into the effects of their changes.
 
-The `--output-diff` flag converts data from exactly two CSV files into a LaTeX /
-PDF table. Conversion to PDF requires `pdflatex` to be installed.
-`bin/warmup_stats` also needs the names of the language and VM under test, and
-the output of `uname -a` on the machine the benchmarks were run on. Example
-usage:
+The `--output-diff` flag converts data from exactly two CSV files into an HTML
+table or a LaTeX / PDF table. Conversion to PDF requires `pdflatex` to be
+installed. `bin/warmup_stats` also needs the names of the language and VM under
+test, and the output of `uname -a` on the machine the benchmarks were run on.
+Example usage (LaTeX / PDF):
 
 ```
-bin/warmup_stats  --output-diff diff.tex -l javascript -v V8 -u "`uname -a`" before.csv after.csv
+bin/warmup_stats --tex --output-diff diff.tex -l javascript -v V8 -u "`uname -a`" before.csv after.csv
 ```
 
-The resulting LaTeX table will contain results from the `after.csv` file,
-compared against the `before.csv` file. VMs and benchmarks that do not appear in
-both CSV results files will be omitted from the table.
+Example usage (HTML):
+
+```
+bin/warmup_stats --html --output-diff diff.html -l javascript -v V8 -u "`uname -a`" before.csv after.csv
+```
+
+The resulting table will contain results from the `after.csv` file, compared
+against the `before.csv` file. VMs and benchmarks that do not appear in both CSV
+results files will be omitted from the table.
 
 
 # Warmup stats from Krun
@@ -165,17 +178,18 @@ are:
 ## Diffing Krun results files
 
 The `bin/diff_results` scripts takes two Krun results files as an input and
-produces a LaTeX file (which can be compiled to PDF with pdflatex or similar)
-as output:
+produces an HTML file or a LaTeX file (which can be compiled to PDF with
+pdflatex or similar) as output:
 
 ```
-bin/diff_results -r BEFORE.json.bz2 AFTER.json.bz2 -o diff.tex -n 1
+bin/diff_results -r BEFORE.json.bz2 AFTER.json.bz2 --html diff.html
+bin/diff_results -r BEFORE.json.bz2 AFTER.json.bz2 --tex diff.tex -n 1
 ```
 
-The `-n` switch controls the number of columns in the table, and we recommend
-setting this to the number of VMs that were benchmarked.
+The `-n` switch (only available with `--tex`) controls the number of columns in
+the table, and we recommend setting this to the number of VMs that were
+benchmarked.
 
-The resulting LaTeX table will contain results from the `AFTER.json.bz2` file,
+The resulting table will contain results from the `AFTER.json.bz2` file,
 compared against the `BEFORE.json.bz2` file. VMs and benchmarks that do not
-appear in both Krun results files will be omitted from the table. The table
-will be automatically converted to PDF (requires `pdflatex` to be installed).
+appear in both Krun results files will be omitted from the table.

--- a/bin/diff_results
+++ b/bin/diff_results
@@ -75,7 +75,22 @@ from warmup.latex import end_document, end_longtable, end_table, escape
 from warmup.latex import get_latex_symbol_map, preamble
 from warmup.latex import start_longtable, start_table, STYLE_SYMBOLS
 from warmup.summary_statistics import BLANK_CELL, collect_summary_statistics
-from warmup.summary_statistics import convert_to_latex
+from warmup.summary_statistics import convert_to_latex, write_html_table
+
+DESCRIPTION = lambda fname: """
+Diff two Krun results files. Input files to this script should already have
+outliers and changepoints marked (i.e. the mark_outliers_in_json and
+mark_changepoints_in_json scripts should already have been run). Output
+can be in HTML or LaTeX. A JSON file containing a raw diff is dumped to disk.
+
+Example usage (input Krun results files, output HTML):
+
+    $ python %s --json diff_summary.json --input-results before.json.bz2 after.json.bz2 --html diff.html
+
+Example usage (input JSON summary file, output LaTeX):
+
+    $ python %s --input-summary diff_summary.json --tex diff.tex
+"""
 
 ALPHA = 0.01  # Significance level.
 CATEGORIES = ['warmup', 'slowdown', 'flat', 'no steady state']
@@ -105,9 +120,14 @@ TABLE_HEADINGS2 = '&&\\multicolumn{1}{c}{Class.} &\\multicolumn{1}{c}{iter (\#)}
 JSON_VERSION_NUMBER = '2'
 
 
+def fatal(message):
+    print(message)
+    sys.exit(1)
+
+
 def legend():
-    key = (colour_cell(BETTER, 'improved'), colour_cell(WORSE, 'worsened'),
-           colour_cell(DIFFERENT, 'different'), colour_cell(SAME, 'unchanged'))
+    key = (colour_tex_cell(BETTER, 'improved'), colour_tex_cell(WORSE, 'worsened'),
+           colour_tex_cell(DIFFERENT, 'different'), colour_tex_cell(SAME, 'unchanged'))
     return '\\textbf{Diff against previous results:} ' + ' '.join(key) + '.'
 
 
@@ -316,7 +336,7 @@ def diff(before_file, after_file, summary_filename):
     return summary
 
 
-def colour_cell(result, text):
+def colour_tex_cell(result, text):
     """Colour a table cell containing `text` according to `result`."""
 
     assert result in (None, SAME, DIFFERENT, BETTER, WORSE)
@@ -391,10 +411,10 @@ def write_latex_table(machine, all_benchs, summary, diff, tex_file, num_splits,
                         classification = ''
                     else:
                         if vm in diff and bench in diff[vm]:
-                            classification = colour_cell(diff[vm][bench][CLASSIFICATIONS], this_summary['style'])
-                            last_cpt = colour_cell(diff[vm][bench][STEADY_ITER], this_summary['last_cpt'])
-                            time_steady = colour_cell(diff[vm][bench][STEADY_ITER], this_summary['time_to_steady_state'])
-                            last_mean = colour_cell(diff[vm][bench][STEADY_STATE_TIME], this_summary['last_mean'])
+                            classification = colour_tex_cell(diff[vm][bench][CLASSIFICATIONS], this_summary['style'])
+                            last_cpt = colour_tex_cell(diff[vm][bench][STEADY_ITER], this_summary['last_cpt'])
+                            time_steady = colour_tex_cell(diff[vm][bench][STEADY_ITER], this_summary['time_to_steady_state'])
+                            last_mean = colour_tex_cell(diff[vm][bench][STEADY_STATE_TIME], this_summary['last_mean'])
                         else:
                             classification = this_summary['style']
                             last_cpt = this_summary['last_cpt']
@@ -426,7 +446,7 @@ def write_latex_table(machine, all_benchs, summary, diff, tex_file, num_splits,
                                time_steady, last_mean]
                     if not row:  # First bench in this row, needs the vm column.
                         if vm in diff and bench in diff[vm]:
-                            bname = colour_cell(diff[vm][bench][INTERSECTION], bench)
+                            bname = colour_tex_cell(diff[vm][bench][INTERSECTION], bench)
                         else:
                             bname = bench
                         row.insert(0, escape(bname))
@@ -460,32 +480,27 @@ def write_latex_table(machine, all_benchs, summary, diff, tex_file, num_splits,
 def create_cli_parser():
     """Create a parser to deal with command line switches."""
 
-    script = os.path.basename(__file__)
-    description = (('Diff two Krun results files. Input files to this script should '
-                    'already have outliers and changepoints marked (i.e. the '
-                    'mark_outliers_in_json and mark_changepoints_in_json scripts '
-                    'should already have been run).\n'
-                    '\n\nExample usage:\n\n'
-                    '\t$ python %s -f before.json.bz2 after.json.bz2 -o diff.tex\n'
-                    '\t$ python %s -s diff_summary.json -o diff.tex') % (script, script))
+    description = DESCRIPTION(os.path.basename(__file__))
     parser = argparse.ArgumentParser(description=description,
                                      formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('-o', '--output', action='store', default='diff_summary.tex',
-                        type=str, help='LaTeX file in which to write diff summary.')
     parser.add_argument('-j', '--json', action='store', default='diff_summary.json',
                         type=str, help='JSON file in which to write diff summary.')
-    parser.add_argument('--num-splits', '-n', action='store',
-                        type=int, help='Number of horizontal splits.',
-                        default=1)
+    parser.add_argument('-n', '--num-splits', action='store', default=1,
+                        type=int, help='Number of horizontal splits (LaTeX only).')
     parser.add_argument('--without-preamble', action='store_true',
                         dest='without_preamble', default=False,
-                        help='Write out only the table (for inclusion in a separate document).')
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('-s', '--summary', action='store', default=None,
-                       type=str, help=('Read summary data from JSON file rather than '
-                                       'generating from a two original results files.'))
-    group.add_argument('-r', '--results-files', nargs=2, action='append', default=[], type=str,
-                       help='Exactly two Krun result files (with outliers and changepoints).')
+                        help='Write out only a LaTeX table, for inclusion in a larger document.')
+    outputs = parser.add_mutually_exclusive_group(required=True)
+    outputs.add_argument('--tex', action='store', type=str,
+                         help='LaTeX file in which to write diff summary.')
+    outputs.add_argument('--html', action='store', type=str,
+                         help='HTML file in which to write diff summary.')
+    inputs = parser.add_mutually_exclusive_group(required=True)
+    inputs.add_argument('-s', '--input-summary', action='store', default=None,
+                        type=str, help=('Read summary data from JSON file rather than '
+                                        'generating from a two original results files.'))
+    inputs.add_argument('-r', '--input-results', nargs=2, action='append', default=[], type=str,
+                        help='Exactly two Krun result files (with outliers and changepoints).')
     return parser
 
 
@@ -493,35 +508,36 @@ if __name__ == '__main__':
     parser = create_cli_parser()
     options = parser.parse_args()
     diff_summary = None
-    if options.summary is None:
-        if '_outliers' not in options.results_files[0][0]:
-            print('Please run mark_outliers_in_json on file %s before diffing.' %
+    if options.html and options.without_preamble:
+        print('--without-preamble only makes sense with LaTeX output. Ignoring.')
+    if options.input_summary is None:
+        if '_outliers' not in options.input_results[0][0]:
+            fatal('Please run mark_outliers_in_json on file %s before diffing.' %
                   options.results_files[0][0])
-            sys.exit(1)
-        if '_outliers' not in options.results_files[0][1]:
-            print ('Please run mark_outliers_in_json on file %s before diffing.' %
-                   options.results_files[0][1])
-            sys.exit(1)
-        if '_changepoints' not in options.results_files[0][0]:
-            print ('Please run mark_changepoints_in_json on file %s before diffing.' %
-                   options.results_files[0][0])
-            sys.exit(1)
-        if '_changepoints' not in options.results_files[0][1]:
-            print ('Please run mark_changepoints_in_json on file %s before diffing.' %
-                   options.results_files[0][1])
-            sys.exit(1)
-        diff_summary = diff(options.results_files[0][0], options.results_files[0][1], options.json)
+        if '_outliers' not in options.input_results[0][1]:
+            fatal('Please run mark_outliers_in_json on file %s before diffing.' %
+                  options.results_files[0][1])
+        if '_changepoints' not in options.input_results[0][0]:
+            fatal('Please run mark_changepoints_in_json on file %s before diffing.' %
+                  options.results_files[0][0])
+        if '_changepoints' not in options.input_results[0][1]:
+            fatal('Please run mark_changepoints_in_json on file %s before diffing.' %
+                  options.results_files[0][1])
+        diff_summary = diff(options.input_results[0][0], options.input_results[0][1], options.json)
     else:
-        with open(options.summary, 'r') as fd:
+        with open(options.input_summary, 'r') as fd:
             diff_summary = json.load(fd)
         if diff_summary is None:
-            print('Could not open %s.' % options.summary)
-            sys.exit(1)
+            fatal('Could not open %s.' % options.input_summary)
     classifier = diff_summary[CLASSIFIER]
-    machine, bmarks, latex_summary = convert_to_latex(diff_summary[AFTER], classifier['delta'],
-                                                      classifier['steady'], diff=diff_summary[DIFF],
-                                                      previous=diff_summary[BEFORE])
-    print('Writing data to: %s' % options.output)
-    write_latex_table(machine, bmarks, latex_summary, diff_summary[DIFF], options.output,
-                      options.num_splits, with_preamble=(not options.without_preamble),
-                      longtable=True)
+    if options.html:
+        print('Writing data to: %s' % options.html)
+        write_html_table(diff_summary[AFTER], options.html, diff=diff_summary[DIFF], previous=diff_summary[BEFORE])
+    if options.tex:
+        machine, bmarks, latex_summary = convert_to_latex(diff_summary[AFTER], classifier['delta'],
+                                                          classifier['steady'], diff=diff_summary[DIFF],
+                                                          previous=diff_summary[BEFORE])
+        print('Writing data to: %s' % options.tex)
+        write_latex_table(machine, bmarks, latex_summary, diff_summary[DIFF], options.tex,
+                          options.num_splits, with_preamble=(not options.without_preamble),
+                          longtable=True)

--- a/bin/warmup_stats
+++ b/bin/warmup_stats
@@ -91,6 +91,34 @@ except ImportError:
     pass
 
 
+DESCRIPTION = lambda fname: """
+Analyse CSV results file and produce a JSON summary, result table, result plots
+or diff table. Tables of results or diffs can be produced in HTML or LaTeX/PDF.
+
+CSV input file(s) should be in the following format:
+
+    process num, bench_name, 0, 1, 2, ...
+    0, spectral norm, 0.2, 0.1, 0.4, ...
+    1, spectral norm, 0.3, 0.15, 0.2, ...
+
+Example usage - output JSON summary:
+
+    $ python %s --output-json summary.json -l javascript -v V8 -u "`uname -a`" results.csv
+
+Example usage - output HTML table:
+
+    $ python %s --html --output-table results.html -l javascript -v V8 -u "`uname -a`" results.csv
+
+Example usage - output PDF plot:
+
+    $ python %s --output-plots plots.pdf -l javascript -v V8 -u "`uname -a`" results.csv
+
+Example usage - output LaTeX/PDF diff:
+
+    $ python %s --tex --output-diff diff.tex -l javascript -v V8 -u "`uname -a`" before.csv after.csv
+""" % (fname, fname, fname, fname)
+
+
 def fatal(msg):
     """Log error and exit."""
     error(msg)
@@ -98,18 +126,7 @@ def fatal(msg):
 
 
 def create_arg_parser():
-    script = os.path.basename(__file__)
-    description = ('Analyse CSV results file and produce JSON, HTML (table) or '
-                   'PDF plots. The CSV input file(s) should be in this format:\n\n'
-                   '\tprocess num, bench_name, 0, 1, 2, ...\n'
-                   '\t0, spectral norm, 0.2, 0.1, 0.4, ...\n'
-                   '\t1, spectral norm, 0.3, 0.15, 0.2, ...\n'
-                   '\n\nExample usage:\n\n\t$ python %s --output-json summary.json '
-                   '-l javascript -v V8 -u "`uname -a`" results.csv'
-                   '\n\nExample usage:\n\n\t$ python %s --output-diff diff.tex '
-                   '-l javascript -v V8 -u "`uname -a`" before.csv after.csv'
-                   % (script, script))
-    parser = argparse.ArgumentParser(description=description,
+    parser = argparse.ArgumentParser(description=DESCRIPTION(os.path.basename(__file__)),
                                      formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('--debug', '-d', action='store', default='WARN',
                         dest='debug_level',
@@ -126,24 +143,29 @@ def create_arg_parser():
     parser.add_argument('--uname', '-u', dest='uname', action='store', default='',
                         required=True, type=str,
                         help='Full output of `uname -a` from benchmarking machine.')
-    # What output should be generated?
-    output_group = parser.add_argument_group('Output formats')
+    # What output file format should be generated?
+    format_group = parser.add_mutually_exclusive_group(required=True)
+    format_group.add_argument('--html', dest='type_html', action='store_true', default=False,
+                              help=('Output an HTML file. Valid with --output-table '
+                                    'and --output-diff.'))
+    format_group.add_argument('--tex', dest='type_latex', action='store_true', default=False,
+                              help=('Output a LaTeX file and convert to PDF. Valid '
+                                    'with --output-table and --output-diff.'))
+    # What output should
+    output_group = parser.add_argument_group('Output format')
     output_group.add_argument('--output-plots', dest='output_plots', action='store',
                               type=str, metavar='PDF_FILENAME', default=None,
-                              help='Output a PDF file containing plots.')
-    output_group.add_argument('--output-html', dest='output_html', action='store',
-                              type=str, metavar='HTML_FILENAME', default=None,
-                              help='Output an HTML file containing tables.')
+                              help='Output a PDF file containing plots (HTML unavailable).')
     output_group.add_argument('--output-table', dest='output_table', action='store',
-                              type=str, metavar='LATEX_FILENAME', default=None,
-                              help='Output a LaTeX file containing table, and convert to PDF.')
+                              type=str, metavar='TABLE_FILENAME', default=None,
+                              help='Output a file containing table. Requires --tex or --html.')
     output_group.add_argument('--output-json', dest='output_json', action='store',
                               type=str, metavar='JSON_FILENAME', default=None,
-                              help='Output a JSON file containing summary results.')
+                              help='Output a JSON file containing a statistical summary.')
     output_group.add_argument('--output-diff', dest='output_diff', action='store',
-                              type=str, metavar='LATEX_FILENAME', default=None,
-                              help='Output a LaTeX file containing a diff table, and '
-                              'convert to PDF. Expects exactly two CSV input files.')
+                              type=str, metavar='DIFF_FILENAME', default=None,
+                              help='Output a file containing a diff table. Requires '
+                              '--tex or --html. Expects exactly two CSV input files.')
     return parser
 
 
@@ -262,13 +284,12 @@ class BenchmarkFile(object):
 
 
 def main(options):
-    need_latex = options.output_table or options.output_diff
+    need_latex = (options.output_table or options.output_diff) and options.type_latex
     need_plots = options.output_plots
-    if (not need_latex and not need_plots and not options.output_html and
-        not options.output_json):
-        fatal('You did not specify an output option! Need one or more of '
-              '--output-json, --output-html, --output-latex, --output-plots '
-              'or --output-diff.')
+    if options.output_table and not (options.type_latex or options.type_html):
+        fatal('--output-table must be used with either --html or --tex.')
+    if options.output_diff and not (options.type_latex or options.type_html):
+        fatal('--output-diff must be used with either --html or --tex.')
     csv_files = options.csv_files[0]
     if options.output_diff and len(csv_files) != 2:
         fatal('--output-diff expects exactly 2 CSV input files.')
@@ -290,11 +311,12 @@ def main(options):
     info('Marking changepoints in JSON.')
     for benchmark in benchmarks:
         benchmark.mark_changepoints()
-    if options.output_diff:
+    if options.output_diff and options.type_latex:
+        info('Generating LaTeX diff table.')
         input_files = [bm.krun_filename_changepoints for bm in benchmarks]
         assert len(input_files) == 2
-        cli = [python_path, SCRIPT_DIFF_RESULTS, '-o',
-               options.output_diff, '-r', ' '.join(input_files)]
+        cli = [python_path, SCRIPT_DIFF_RESULTS, '--tex', options.output_diff,
+               '--input-results', ' '.join(input_files)]
         debug('Running: %s' % ' '.join(cli))
         output = subprocess.check_output(' '.join(cli), shell=True)
         for line in output.strip().split('\n'):
@@ -304,7 +326,18 @@ def main(options):
         cli = [pdflatex_path, '-interaction=batchmode', options.output_diff]
         debug('Running: %s' % ' '.join(cli))
         _ = subprocess.check_output(' '.join(cli), shell=True)
-    if options.output_json or options.output_table or options.output_html:
+    if options.output_diff and options.type_html:
+        info('Generating HTML diff table.')
+        input_files = [bm.krun_filename_changepoints for bm in benchmarks]
+        assert len(input_files) == 2
+        cli = [python_path, SCRIPT_DIFF_RESULTS, '--html', options.output_diff,
+               '--input-results', ' '.join(input_files)]
+        debug('Running: %s' % ' '.join(cli))
+        output = subprocess.check_output(' '.join(cli), shell=True)
+        for line in output.strip().split('\n'):
+            if line.startswith('Writing data to:'):
+                debug('Written out: %s' % line.split(' ')[-1])
+    if options.output_json or options.output_table:
         info('Collecting summary statistics.')
         input_files = [bm.krun_filename_changepoints for bm in benchmarks]
         classifier, data_dictionary = parse_krun_file_with_changepoints(input_files)
@@ -333,7 +366,7 @@ def main(options):
         with open(options.output_json, 'w') as fd:
             json.dump(summary, fd, sort_keys=True, ensure_ascii=True, indent=4)
         debug('Written out: %s' % options.output_json)
-    if options.output_table:
+    if options.output_table and options.type_latex:
         info('Generating LaTeX / PDF table.')
         machine, bmarks, latex_summary = convert_to_latex(summary, classifier['delta'], classifier['steady'])
         num_splits = 1
@@ -345,9 +378,9 @@ def main(options):
         cli = [pdflatex_path, '-interaction=batchmode', options.output_table]
         debug('Running: %s' % ' '.join(cli))
         _ = subprocess.check_output(' '.join(cli), shell=True)
-    if options.output_html:
+    if options.output_table and options.type_html:
         info('Generating HTML table.')
-        write_html_table(summary, options.output_html)
+        write_html_table(summary, options.output_table)
 
 
 if __name__ == '__main__':

--- a/warmup/html.py
+++ b/warmup/html.py
@@ -64,7 +64,10 @@ th                 { background-color: black;
                      color: white;
                      text-align: left;
                      padding: 8px; }
-tr:nth-child(even) { background-color: "#f2f2f2"; }
+tr:nth-child(even) { background-color: #f2f2f2; }
+#lightred          { background-color: #e88a8a; }
+#lightyellow       { background-color: #e8e58a; }
+#lightgreen        { background-color: #8ae89c; }
 </style>
 </head>
 <body>
@@ -73,3 +76,14 @@ tr:nth-child(even) { background-color: "#f2f2f2"; }
 </body>
 </html>
 """  # Strings from HTML_TABLE_TEMPLATE.
+
+
+DIFF_LEGEND = """
+<p>
+<strong>Diff against previous results:</strong>
+<span id="lightgreen">improved</span>
+<span id="lightred">worsened</span>
+<span id="lightyellow">different</span>
+<span>unchanged.</span>
+</p>
+"""

--- a/warmup/summary_statistics.py
+++ b/warmup/summary_statistics.py
@@ -289,7 +289,7 @@ def convert_to_latex(summary_data, delta, steady_state, diff=None, previous=None
                                      bmark['detailed_classification'][bmark['classification']])
             if bmark['steady_state_iteration'] is not None:
                 change = None
-                if diff and diff[vm][bmark_name] and diff[vm][bmark_name][STEADY_ITER] > 0 and \
+                if diff and diff[vm][bmark_name] and diff[vm][bmark_name][STEADY_ITER] != SAME and \
                         previous['machines'][machine][vm][bmark_name]['steady_state_iteration']:
                     change = bmark['steady_state_iteration'] - \
                         previous['machines'][machine][vm][bmark_name]['steady_state_iteration']
@@ -302,7 +302,7 @@ def convert_to_latex(summary_data, delta, steady_state, diff=None, previous=None
                 mean_steady_iter = ''
             if bmark['steady_state_time'] is not None:
                 change = None
-                if diff and diff[vm][bmark_name] and diff[vm][bmark_name][STEADY_STATE_TIME] > 0 and \
+                if diff and diff[vm][bmark_name] and diff[vm][bmark_name][STEADY_STATE_TIME] != SAME and \
                         previous['machines'][machine][vm][bmark_name]['steady_state_time_ci']:
                     change = bmark['steady_state_time'] - \
                         previous['machines'][machine][vm][bmark_name]['steady_state_time']
@@ -314,7 +314,7 @@ def convert_to_latex(summary_data, delta, steady_state, diff=None, previous=None
                 mean_steady = ''
             if bmark['steady_state_time_to_reach_secs'] is not None:
                 change = None
-                if diff and diff[vm][bmark_name] and diff[vm][bmark_name][STEADY_ITER] > 0 and \
+                if diff and diff[vm][bmark_name] and diff[vm][bmark_name][STEADY_ITER] != SAME and \
                         previous['machines'][machine][vm][bmark_name]['steady_state_time_to_reach_secs']:
                     change = bmark['steady_state_time_to_reach_secs'] - \
                         previous['machines'][machine][vm][bmark_name]['steady_state_time_to_reach_secs']

--- a/warmup/summary_statistics.py
+++ b/warmup/summary_statistics.py
@@ -39,7 +39,7 @@ import json
 import math
 
 from collections import Counter, OrderedDict
-from warmup.html import HTML_TABLE_TEMPLATE, HTML_PAGE_TEMPLATE
+from warmup.html import DIFF_LEGEND, HTML_TABLE_TEMPLATE, HTML_PAGE_TEMPLATE
 from warmup.latex import end_document, end_longtable, end_table, escape, format_median_ci
 from warmup.latex import format_median_error, get_latex_symbol_map, preamble
 from warmup.latex import start_longtable, start_table, STYLE_SYMBOLS
@@ -447,7 +447,26 @@ def write_latex_table(machine, all_benchs, summary, tex_file, num_splits,
             fp.write(end_document())
 
 
-def write_html_table(summary_data, html_filename):
+def colour_html_cell(result, text, align=None):
+    """Colour a table cell containing `text` according to `result`."""
+
+    assert result in (None, SAME, DIFFERENT, BETTER, WORSE)
+    if result == BETTER:
+        colour = 'id="lightgreen"'
+    elif result == WORSE:
+        colour = 'id="lightred"'
+    elif result == DIFFERENT:
+        colour = 'id="lightyellow"'
+    else:
+        colour = ''
+    if align:
+        text_align = 'style="text-align: %s"' % align
+    else:
+        text_align = ''
+    return '<td %s %s>%s</td>' % (text_align, colour, text)
+
+
+def write_html_table(summary_data, html_filename, diff=None, previous=None):
     assert 'warmup_format_version' in summary_data and summary_data['warmup_format_version'] == JSON_VERSION_NUMBER, \
         'Cannot process data from old JSON formats.'
     machine = None
@@ -490,30 +509,71 @@ def write_html_table(summary_data, html_filename):
             else:  # No inconsistencies, but some process executions errored.
                 reported_category = ' %s %d' % (bmark['classification'],
                                      bmark['detailed_classification'][bmark['classification']])
+            if diff and vm in diff and bmark_name in diff[vm]:
+                category_cell = colour_html_cell(diff[vm][bmark_name][CLASSIFICATIONS], reported_category)
+            else:
+                category_cell = '<td>%s</td>' % reported_category
             if bmark['steady_state_iteration'] is not None:
-                mean_steady_iter = '%d (%d, %d)' % (int(math.ceil(bmark['steady_state_iteration'])),
-                                                    int(math.ceil(bmark['steady_state_iteration_iqr'][0])),
-                                                    int(math.ceil(bmark['steady_state_iteration_iqr'][1])))
+                change = ''
+                if diff and vm in diff and bmark_name in diff[vm] and diff[vm][bmark_name][STEADY_ITER] != SAME and \
+                        previous['machines'][machine][vm][bmark_name]['steady_state_iteration']:
+                    delta = bmark['steady_state_iteration'] - \
+                        previous['machines'][machine][vm][bmark_name]['steady_state_iteration']
+                    change = '<br/><small>&delta;=%.1f</small>' % delta
+                mean_steady_iter = '%.1f%s<br/><small>(%.1f, %.1f)</small>' % \
+                    (bmark['steady_state_iteration'], change,
+                     bmark['steady_state_iteration_iqr'][0], bmark['steady_state_iteration_iqr'][1])
+                if diff and vm in diff and bmark_name in diff[vm]:
+                    mean_steady_iter_cell = colour_html_cell(diff[vm][bmark_name][STEADY_ITER], mean_steady_iter, align="center")
+                else:
+                    mean_steady_iter_cell = '<td style="text-align: center;">%s</td>' % mean_steady_iter
             else:
-                mean_steady_iter = ''
+                mean_steady_iter_cell = '<td></td>'
             if bmark['steady_state_time'] is not None:
-                mean_steady = '%.5f&plusmn;%.6f' % (bmark['steady_state_time'],
-                                                    bmark['steady_state_time_ci'])
+                change = ''
+                if diff and vm in diff and bmark_name in diff[vm] and diff[vm][bmark_name][STEADY_STATE_TIME] != SAME and \
+                        previous['machines'][machine][vm][bmark_name]['steady_state_time']:
+                    delta = bmark['steady_state_time'] - \
+                        previous['machines'][machine][vm][bmark_name]['steady_state_time']
+                    change = '<br/><small>&delta;=%.6f</small>' % delta
+                mean_steady = '%.5f%s<br/><small>&plusmn;%.6f</small>' % (bmark['steady_state_time'],
+                                                                          change,
+                                                                          bmark['steady_state_time_ci'])
+                if diff and vm in diff and bmark_name in diff[vm]:
+                    mean_steady_cell = colour_html_cell(diff[vm][bmark_name][STEADY_STATE_TIME], mean_steady, align="right")
+                else:
+                    mean_steady_cell = '<td style="text-align: right;">%s</td>' % mean_steady
             else:
-                mean_steady = ''
+                mean_steady_cell = '<td></td>'
             if bmark['steady_state_time_to_reach_secs'] is not None:
-                time_to_steady = '%.3f (%.3f, %.3f)' % (bmark['steady_state_time_to_reach_secs'],
-                                                        bmark['steady_state_time_to_reach_secs_iqr'][0],
-                                                        bmark['steady_state_time_to_reach_secs_iqr'][1])
+                change = ''
+                if diff and vm in diff and bmark_name in diff[vm] and diff[vm][bmark_name][STEADY_ITER] != SAME and \
+                        previous['machines'][machine][vm][bmark_name]['steady_state_time_to_reach_secs']:
+                    delta = bmark['steady_state_time_to_reach_secs'] - \
+                        previous['machines'][machine][vm][bmark_name]['steady_state_time_to_reach_secs']
+                    change = '<br/><small>&delta;=%.3f</small>' % delta
+                time_to_steady = '%.3f%s<br/><small>(%.3f, %.3f)</small>' % (bmark['steady_state_time_to_reach_secs'],
+                                                                             change,
+                                                                             bmark['steady_state_time_to_reach_secs_iqr'][0],
+                                                                             bmark['steady_state_time_to_reach_secs_iqr'][1])
+                if diff and vm in diff and bmark_name in diff[vm]:
+                    time_steady_cell = colour_html_cell(diff[vm][bmark_name][STEADY_ITER], time_to_steady, align="center")
+                else:
+                    time_steady_cell = '<td style="text-align: center;">%s</td>' % time_to_steady
             else:
-                time_to_steady = ''
+                time_steady_cell = '<td></td>'
+            if diff and vm in diff and bmark_name in diff[vm]:
+                bmark_cell = colour_html_cell(diff[vm][bmark_name][INTERSECTION], bmark_name)
+            else:
+                bmark_cell = '<td>%s</td>' % bmark_name
             # Benchmark name, classification, steady iter, time to reach, steady perf
-            row = ('<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>\n' %
-                   (bmark_name, reported_category, mean_steady_iter,
-                    time_to_steady, mean_steady))
+            row = ('<tr>%s%s%s%s%s</tr>\n' %
+                   (bmark_cell, category_cell, mean_steady_iter_cell, time_steady_cell, mean_steady_cell))
             html_rows += row
         html_table_contents[vm] = html_rows
     page_contents = ''
+    if diff:
+        page_contents += DIFF_LEGEND
     for vm in html_table_contents:
         page_contents += HTML_TABLE_TEMPLATE % (vm, html_table_contents[vm])
         page_contents += '\n\n'


### PR DESCRIPTION
**PLEASE DO NOT MERGE JUST YET**

This is the first (of two) PRs to address Issue #18 (the second PR will add histograms). This PR adds HTML diff tables, which are coloured similarly to the PDF tables. Currently deltas are missing, and the README needs updating.

Example PDF file: [tom2.pdf](https://github.com/softdevteam/warmup_stats/files/1711833/tom2.pdf)

Equivalent HTML:

![screenshot from 2018-02-09 17-15-59](https://user-images.githubusercontent.com/97674/36040291-ef5ef490-0dbc-11e8-98a1-e207ee7100f8.png)


This PR significantly changes the CLI options for `warmup_stats` and `diff_result`, which will affect end users:

```sh
$ ./bin/warmup_stats --help
usage: warmup_stats [-h] [--debug DEBUG_LEVEL] --language LANGUAGE --vm VM
                    --uname UNAME (--html | --tex)
                    [--output-plots PDF_FILENAME]
                    [--output-table TABLE_FILENAME]
                    [--output-json JSON_FILENAME]
                    [--output-diff DIFF_FILENAME]
                    csv_files [csv_files ...]

Analyse CSV results file and produce a JSON summary, result table, result plots
or diff table. Tables of results or diffs can be produced in HTML or LaTeX/PDF.

CSV input file(s) should be in the following format:

    process num, bench_name, 0, 1, 2, ...
    0, spectral norm, 0.2, 0.1, 0.4, ...
    1, spectral norm, 0.3, 0.15, 0.2, ...

Example usage - output JSON summary:

    $ python warmup_stats --output-json summary.json -l javascript -v V8 -u "`uname -a`" results.csv

Example usage - output HTML table:

    $ python warmup_stats --html --output-table results.tex -l javascript -v V8 -u "`uname -a`" results.csv

Example usage - output PDF plot:

    $ python warmup_stats --output-plots plots.pdf -l javascript -v V8 -u "`uname -a`" results.csv

Example usage - output LaTeX/PDF diff:

    $ python warmup_stats --tex --output-diff diff.tex -l javascript -v V8 -u "`uname -a`" before.csv after.csv

positional arguments:
  csv_files             One or more CSV result files.

optional arguments:
  -h, --help            show this help message and exit
  --debug DEBUG_LEVEL, -d DEBUG_LEVEL
                        Debug level used by logger. Must be one of: DEBUG, INFO, WARN, DEBUG, CRITICAL, ERROR
  --language LANGUAGE, -l LANGUAGE
                        Language under test (in lower-case).
  --vm VM, -v VM        Virtual machine under test (in title-case).
  --uname UNAME, -u UNAME
                        Full output of `uname -a` from benchmarking machine.
  --html                Output an HTML file. Valid with --output-table and --output-diff.
  --tex                 Output a LaTeX file and convert to PDF. Valid with --output-table and --output-diff.

Output format:
  --output-plots PDF_FILENAME
                        Output a PDF file containing plots (HTML unavailable).
  --output-table TABLE_FILENAME
                        Output a file containing table. Requires --tex or --html.
  --output-json JSON_FILENAME
                        Output a JSON file containing a statistical summary.
  --output-diff DIFF_FILENAME
                        Output a file containing a diff table. Requires --tex or --html. Expects exactly two CSV input files.

$ ./bin/diff_results -h
Note: no visible global function definition for 'radixsort' 
usage: diff_results [-h] [-j JSON] [-n NUM_SPLITS] [--without-preamble]
                    (-l OUTPUT_LATEX | -m OUTPUT_HTML)
                    (-s INPUT_SUMMARY | -r INPUT_RESULTS INPUT_RESULTS)

Diff two Krun results files. Input files to this script should already have
outliers and changepoints marked (i.e. the mark_outliers_in_json and
mark_changepoints_in_json scripts should already have been run). Output
can be in HTML or LaTeX. A JSON file containing a raw diff is dumped to disk.

Example usage (input Krun results files, output HTML):

    $ python %s --json diff_summary.json --input-results before.json.bz2 after.json.bz2 --output-html diff.html

Example usage (input JSON summary file, output LaTeX):

    $ python %s --input-summary diff_summary.json --output-latex diff.tex

optional arguments:
  -h, --help            show this help message and exit
  -j JSON, --json JSON  JSON file in which to write diff summary.
  -n NUM_SPLITS, --num-splits NUM_SPLITS
                        Number of horizontal splits (LaTeX only).
  --without-preamble    Write out only a LaTeX table, for inclusion in a larger document.
  -l OUTPUT_LATEX, --output-latex OUTPUT_LATEX
                        LaTeX file in which to write diff summary.
  -m OUTPUT_HTML, --output-html OUTPUT_HTML
                        HTML file in which to write diff summary.
  -s INPUT_SUMMARY, --input-summary INPUT_SUMMARY
                        Read summary data from JSON file rather than generating from a two original results files.
  -r INPUT_RESULTS INPUT_RESULTS, --input-results INPUT_RESULTS INPUT_RESULTS
                        Exactly two Krun result files (with outliers and changepoints).
```

/cc @fsfod 