### PR TITLE
warmup_stats can take Krun JSON files as input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,24 @@
 # warmup_stats
 
 This system has various scripts for analysing the output of VM benchmarking. Any
-system can be used to perform the benchmarking (e.g. Krun
-http://soft-dev.org/src/krun/).
-
+system can be used to perform the benchmarking, e.g.
+[Krun](http://soft-dev.org/src/krun/).
 
 # Installation
 
 First run the `build.sh` script which should perform most, if not all, of the
 installation work needed.
 
-
 # Basic usage
 
-Krun users should see later in this README, but for non-Krun users, the main
-interface is the `bin/warmup_stats` script which takes in files and produces
-various types of plots and tables.
+User should directly call the `bin/warmup_stats`, which is a front-end to other
+scripts in `bin/`. `warmup_stats` takes either CSV files or [Krun](http://soft-
+dev.org/src/krun/) results files as input. As output it can create HTML or LaTeX
+/ PDF tables and diffs, or PDF plots.
 
 ## CSV format
 
-The `bin/warmup_stats` script takes CSV files as input. The format is as
+The `bin/warmup_stats` script can take CSV files as input. The format is as
 follows. The first row must contain a header with a process execution id,
 benchmark name and sequence of iteration numbers. Subsequent rows are data rows,
 one per process execution. Each row should contain an index for the given
@@ -33,37 +32,47 @@ number of iterations as described in the header. For example:
     1, spectral norm, 0.3, 0.15, 0.2, ...
 ```
 
+When processing CSV files with `warmup_stats`, the `--language`, `--vm` and
+`--uname` switches must be passed to the script. These are not needed with
+Krun results files.
 
 ## Creating plots
 
 The `--output-plots <file.pdf>` flag converts input data into visual plots.
-`bin/warmup_stats` also needs the names of the language and VM under test, and
-the output of `uname -a` on the machine the benchmarks were run on. Example
-usage:
+
+If the input files are in CSV format, `bin/warmup_stats` also needs the names of
+the language and VM under test, and the output of `uname -a` on the machine the
+benchmarks were run on.
+
+Example usage:
 
 ```
 bin/warmup_stats  --output-plots plots.pdf --output-json summary.json -l javascript -v V8 -u "`uname -a`" results.csv
+bin/warmup_stats  --output-plots plots.pdf --output-json summary.json results.json.bz2
 ```
-
 
 ## Creating tables
 
 The `--output-table <file>` flag converts input data into an HTML table or a
 LaTeX / PDF table. Conversion to PDF requires `pdflatex` to be installed.
-`bin/warmup_stats` also needs the names of the language and VM under test, and
-the output of `uname -a` on the machine the benchmarks were run on. Example
-usage (LaTeX / PDF):
+
+If the input files are in CSV format, `bin/warmup_stats` also needs the names of
+the language and VM under test, and the output of `uname -a` on the machine the
+benchmarks were run on.
+
+Example usage (LaTeX / PDF):
 
 ```
 bin/warmup_stats --tex --output-table table.tex -l javascript -v V8 -u "`uname -a`" results.csv
+bin/warmup_stats --tex --output-table table.tex results.json.bz2
 ```
 
 Example usage (HTML):
 
 ```
 bin/warmup_stats --html --output-table table.html -l javascript -v V8 -u "`uname -a`" results.csv
+bin/warmup_stats --html --output-table table.html results.json.bz2
 ```
-
 
 ## Creating diffs
 
@@ -75,121 +84,26 @@ want to produce a detailed comparison of the results in Krun results tables
 
 The `--output-diff` flag converts data from exactly two CSV files into an HTML
 table or a LaTeX / PDF table. Conversion to PDF requires `pdflatex` to be
-installed. `bin/warmup_stats` also needs the names of the language and VM under
-test, and the output of `uname -a` on the machine the benchmarks were run on.
+installed.
+
+If the input files are in CSV format, `bin/warmup_stats` also needs the names of
+the language and VM under test, and the output of `uname -a` on the machine the
+benchmarks were run on.
+
 Example usage (LaTeX / PDF):
 
 ```
 bin/warmup_stats --tex --output-diff diff.tex -l javascript -v V8 -u "`uname -a`" before.csv after.csv
+bin/warmup_stats --tex --output-diff diff.tex before.json.bz2 after.json.bz2
 ```
 
 Example usage (HTML):
 
 ```
 bin/warmup_stats --html --output-diff diff.html -l javascript -v V8 -u "`uname -a`" before.csv after.csv
+bin/warmup_stats --html --output-diff diff.html before.json.bz2 after.json.bz2
 ```
 
-The resulting table will contain results from the `after.csv` file, compared
-against the `before.csv` file. VMs and benchmarks that do not appear in both CSV
-results files will be omitted from the table.
-
-
-# Warmup stats from Krun
-
-## Initial statistical scripts
-
-Before generating tables or charts from your Krun data, you will need to run two
-scripts to add *outliers* and *changepoints* to your data.
-
-To add outliers to your Krun output, run:
-
-```
-bin/mark_outliers_in_json -w 200 myresults.json.bz2
-```
-
-`-w` gives the size of the sliding window used to draw percentiles. We recommend
-that you set this to 0.1 * the number of in-process iterations in each process
-execution of your benchmarks (for example, we used 2000 iterations and a window
-size of 200).
-
-This script will generate a new Krun output file called
-`myresults_outliers_w200.json.bz2`.
-
-To add changepoints to your Krun output, run:
-
-```
-bin/mark_changepoints_in_json -s 500 myresults_outliers_200.json.bz2
-```
-
-Note that we run this script **on the output of the `mark_outliers` script**.
-
-In the example invocation above, we stated `-s 500` which tells the script to
-expect that the VM will reach a steady state should be reached before the last
-500 in-process iterations. We recommend that this value be set at 0.25 * the
-number of in-process iterations in each process execution of your benchmarks
-(for example, we used 2000 iterations and a `-s` value of 500).
-
-The invocation of this script shown above will generate a new Krun results file
-called `myresults_outliers_w200_changepoints.json.bz2`. When generating tables
-and plots, this is the version of your results that should be passed to the
-tabling or plotting scripts.
-
-
-## Generating tables from Krun results files
-
-`bin/table_classification_summaries_others` plots summary tables with various
-statistics, and is useful for getting an overall view of a VM(s) performance.
-An example run is as follows:
-
-```
-bin/table_classification_summaries_others -s 1 -o mytable.tex myresults_outliers_w200_changepoints.json.bz2
-```
-
-where `-s 1` gives the number of VMs which were benchmarked. By default, the
-script will generate a stand-alone LaTeX file which can be compiled to PDF
-with `pdflatex`, or similar. If you want to copy and paste the LaTeX output into
-a larger document, use the `--without-preamble`, and provide the relevant LaTeX
-packages in your own preamble.
-
-
-## Generating charts from Krun results files
-
-If you have followed the instructions in the `Initial statistical scripts`
-section above, you will be able to generate plots similar to the ones you can
-see in the paper "Virtual Machine Warmup Blows Hot and Cold". The plotting
-script `bin/plot_krun_results` has a large number of command-line options, but
-will commonly be invoked as follows:
-
-```
-bin/plot_krun_results --with-outliers --with-changepoint-means -w 200 -o myplots.pdf myresults_outliers_200.json.bz2
-```
-
-If you need more tailored output, it is wise to run
-`bin/plot_krun_results --help` and read through the options. There are a large
-number of switches to this script, but ones that users are most likely to need
-are:
-
-  * `-b` to generate only a few plots from a larger data set
-  * `--export-size` to resize plots for publication
-  * `--wallclock-only` to suppress most details
-  * `--xlimits` and `--inset-xlimits` to "zoom in" on parts of the x-axis
-
-
-## Diffing Krun results files
-
-The `bin/diff_results` scripts takes two Krun results files as an input and
-produces an HTML file or a LaTeX file (which can be compiled to PDF with
-pdflatex or similar) as output:
-
-```
-bin/diff_results -r BEFORE.json.bz2 AFTER.json.bz2 --html diff.html
-bin/diff_results -r BEFORE.json.bz2 AFTER.json.bz2 --tex diff.tex -n 1
-```
-
-The `-n` switch (only available with `--tex`) controls the number of columns in
-the table, and we recommend setting this to the number of VMs that were
-benchmarked.
-
-The resulting table will contain results from the `AFTER.json.bz2` file,
-compared against the `BEFORE.json.bz2` file. VMs and benchmarks that do not
-appear in both Krun results files will be omitted from the table.
+The resulting table will contain results from the `after.{csv,json.bz2}` file,
+compared against the `before.{csv,json.bz2}` file. VMs and benchmarks that do
+not appear in both CSV results files will be omitted from the table.

--- a/bin/warmup_stats
+++ b/bin/warmup_stats
@@ -62,6 +62,7 @@ from distutils.spawn import find_executable
 from logging import debug, error, info, warn
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from warmup.krun_results import csv_to_krun_json, parse_krun_file_with_changepoints
+from warmup.krun_results import read_krun_results_file
 from warmup.summary_statistics import collect_summary_statistics, convert_to_latex
 from warmup.summary_statistics import write_html_table, write_latex_table
 
@@ -92,14 +93,18 @@ except ImportError:
 
 
 DESCRIPTION = lambda fname: """
-Analyse CSV results file and produce a JSON summary, result table, result plots
-or diff table. Tables of results or diffs can be produced in HTML or LaTeX/PDF.
+Analyse CSV or Krun results file(s) and produce a JSON summary, result table,
+result plots or diff table. Tables of results or diffs can be produced in HTML
+or LaTeX/PDF.
 
-CSV input file(s) should be in the following format:
+Input files may be in the following CSV format:
 
     process num, bench_name, 0, 1, 2, ...
     0, spectral norm, 0.2, 0.1, 0.4, ...
     1, spectral norm, 0.3, 0.15, 0.2, ...
+
+or be json.bz2 files, output by the Krun(*) tool.
+(*) Krun: http://soft-dev.org/src/krun/
 
 Example usage - output JSON summary:
 
@@ -107,7 +112,7 @@ Example usage - output JSON summary:
 
 Example usage - output HTML table:
 
-    $ python %s --html --output-table results.html -l javascript -v V8 -u "`uname -a`" results.csv
+    $ python %s --html --output-table results.html -l javascript -v V8 -u "`uname -a`" results.json.bz2
 
 Example usage - output PDF plot:
 
@@ -128,21 +133,18 @@ def fatal(msg):
 def create_arg_parser():
     parser = argparse.ArgumentParser(description=DESCRIPTION(os.path.basename(__file__)),
                                      formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('input_files', nargs='+', action='append', default=[],
+                        type=str, help='One or more CSV or Krun results files.')
     parser.add_argument('--debug', '-d', action='store', default='WARN',
                         dest='debug_level',
                         help='Debug level used by logger. Must be one of: '
                              'DEBUG, INFO, WARN, DEBUG, CRITICAL, ERROR')
-    parser.add_argument('csv_files', nargs='+', action='append', default=[],
-                        type=str, help='One or more CSV result files.')
     parser.add_argument('--language', '-l', dest='language', action='store',
-                        type=str,  required=True,
-                        help='Language under test (in lower-case).')
+                        type=str, help='Language under test (in lower-case).')
     parser.add_argument('--vm', '-v', dest='vm', action='store', type=str,
-                        required=True,
                         help='Virtual machine under test (in title-case).')
     parser.add_argument('--uname', '-u', dest='uname', action='store', default='',
-                        required=True, type=str,
-                        help='Full output of `uname -a` from benchmarking machine.')
+                        type=str, help='Full output of `uname -a` from benchmarking machine.')
     # What output file format should be generated?
     format_group = parser.add_mutually_exclusive_group(required=True)
     format_group.add_argument('--html', dest='type_html', action='store_true', default=False,
@@ -151,7 +153,7 @@ def create_arg_parser():
     format_group.add_argument('--tex', dest='type_latex', action='store_true', default=False,
                               help=('Output a LaTeX file and convert to PDF. Valid '
                                     'with --output-table and --output-diff.'))
-    # What output should
+    # What output should warmup_stats generate?
     output_group = parser.add_argument_group('Output format')
     output_group.add_argument('--output-plots', dest='output_plots', action='store',
                               type=str, metavar='PDF_FILENAME', default=None,
@@ -171,6 +173,7 @@ def create_arg_parser():
 
 def setup_logging(options):
     """Setup logging. Logging level passed in on command line."""
+
     level_str = options.debug_level.upper()
     if level_str not in ('DEBUG', 'INFO', 'WARN', 'DEBUG', 'CRITICAL', 'ERROR'):
         fatal('Bad debug level: %s' % level_str)
@@ -231,9 +234,8 @@ def check_environment(need_outliers=True, need_changepoints=True, need_latex=Tru
 class BenchmarkFile(object):
     """Information about each benchmark, including CLI options to other scripts."""
 
-    def __init__(self, csv_filename, options, python_path, pypy_path, pdflatex_path, r_path):
-        self.basename = os.path.splitext(csv_filename)[0]
-        self.csv_filename = csv_filename
+    def __init__(self, filename, options, python_path, pypy_path, pdflatex_path, r_path):
+        self.basename = os.path.splitext(filename)[0]
         self.language = options.language
         self.vm = options.vm
         self.uname = options.uname
@@ -241,12 +243,54 @@ class BenchmarkFile(object):
         self.pypy_path = pypy_path
         self.pdflatex_path = pdflatex_path
         self.r_path = r_path
+        self.csv_filename = None
+        self.krun_filename = None
+        self.krun_filename_outliers = None
+        self.krun_filename_changepoints = None
+        assert filename.endswith('.csv') or filename.endswith('.json.bz2'), \
+            'Unknown file type: %s. Please use CSV or Krun output.' % filename
+        if filename.endswith('.csv'):
+            self.csv_filename = filename
+            # self.iterations is set in self.convert_to_krun_json().
+        if filename.endswith('_changepoints.json.bz2'):
+            self.krun_filename_changepoints = filename
+        if '_outliers_w' in filename:
+            self.krun_filename_outliers = filename
+        if filename.endswith('.json.bz2'):
+            self.krun_filename = filename
+            if not os.path.exists(filename):
+                fatal('File %s does not exist.' % filename)
+            # If the input file comes from Krun, we must still set
+            # self.iterations, which is needed by other methods. We assume the
+            # same number of iterations for all pexecs.
+            data = read_krun_results_file(filename)
+            found_full_pexec = False
+            for bench in data['wallclock_times']:
+                if found_full_pexec:
+                    break
+                for pexec in data['wallclock_times'][bench]:
+                    if pexec == []:  # Crashed benchmark.
+                        continue
+                    else:
+                        self.iterations = len(pexec)
+                        debug('%d iterations per pexec in %s.' % (self.iterations, filename))
+                        found_full_pexec = True
+                        break
+            if not found_full_pexec:
+                fatal('Could not find a non-crashing pexec in %s.' % filename)
 
     def check_input_file(self):
-        if not (os.path.isfile(self.csv_filename) and os.access(self.csv_filename, os.R_OK)):
+        if not self.csv_filename and not (os.path.isfile(self.krun_filename) and
+                                          os.access(self.krun_filename, os.R_OK)):
+            fatal('File %s not found.' % self.krun_filename)
+        if self.csv_filename and not (os.path.isfile(self.csv_filename) and
+                                      os.access(self.csv_filename, os.R_OK)):
             fatal('File %s not found.' % self.csv_filename)
 
     def convert_to_krun_json(self):
+        if self.krun_filename is not None:
+            debug('Krun file already exists: %s' % self.krun_filename)
+            return
         header, self.krun_filename = csv_to_krun_json([self.csv_filename],
                                              self.language, self.vm, self.uname)
         info('Writing out: %s' % self.krun_filename)
@@ -262,6 +306,9 @@ class BenchmarkFile(object):
         assert False
 
     def mark_outliers(self):
+        if self.krun_filename_outliers is not None:
+            debug('Krun file already has outliers: %s' % self.krun_filename_outliers)
+            return
         self.window = int(self.iterations * DEFAULT_WINDOW_RATIO)
         python_runner = self.python_path
         # mark_outliers_in_json is optimised for PyPy.
@@ -274,6 +321,9 @@ class BenchmarkFile(object):
         debug('Written out: %s' % self.krun_filename_outliers)
 
     def mark_changepoints(self):
+        if self.krun_filename_changepoints is not None:
+            debug('Krun file already has changepoints: %s' % self.krun_filename_changepoints)
+            return
         self.steady = int(self.iterations * DEFAULT_STEADY_RATIO)
         cli = [self.python_path, SCRIPT_MARK_CHANGEPOINTS, '-s', str(self.steady),
                self.krun_filename_outliers]
@@ -284,33 +334,48 @@ class BenchmarkFile(object):
 
 
 def main(options):
+    info('Checking sanity of CLI options.')
     need_latex = (options.output_table or options.output_diff) and options.type_latex
     need_plots = options.output_plots
     if options.output_table and not (options.type_latex or options.type_html):
         fatal('--output-table must be used with either --html or --tex.')
     if options.output_diff and not (options.type_latex or options.type_html):
         fatal('--output-diff must be used with either --html or --tex.')
-    csv_files = options.csv_files[0]
-    if options.output_diff and len(csv_files) != 2:
+    input_files = options.input_files[0]
+    for filename in input_files:
+        if filename.endswith('.csv'):
+            if not options.language:
+                fatal('--language or -l must be used with CSV input files.')
+            if not options.vm:
+                fatal('--vm or -v must be used with CSV input files.')
+            if not options.uname:
+                fatal('--uname or -u must be used with CSV input files.')
+    if options.output_diff and len(input_files) != 2:
         fatal('--output-diff expects exactly 2 CSV input files.')
     python_path, pypy_path, pdflatex_path, r_path = check_environment(need_latex=need_latex,
                                                                       need_plots=need_plots)
-    info('Converting CSV to Krun JSON format.')
+    info('Processing input files, converting to Krun JSON if necessary.')
     benchmarks = list()
-    for filename in csv_files:
+    for filename in input_files:
+        if not (filename.endswith('.csv') or filename.endswith('json.bz2')):
+            fatal('Cannot determine filetype of %s. Please use .csv or .json.bz2 (Krun) files only.' % filename)
         benchmarks.append(BenchmarkFile(filename, options, python_path, pypy_path, pdflatex_path, r_path))
     info('Checking input files.')
     for benchmark in benchmarks:
         benchmark.check_input_file()
     info('Converting CSV to Krun JSON.')
     for benchmark in benchmarks:
-        benchmark.convert_to_krun_json()
+        if benchmark.csv_filename:
+            benchmark.convert_to_krun_json()
     info('Marking outliers in JSON.')
     for benchmark in benchmarks:
-        benchmark.mark_outliers()
+        if not benchmark.krun_filename_outliers:
+            benchmark.mark_outliers()
     info('Marking changepoints in JSON.')
     for benchmark in benchmarks:
-        benchmark.mark_changepoints()
+        if not benchmark.krun_filename_changepoints:
+            benchmark.mark_changepoints()
+    # Generate appropriate output.
     if options.output_diff and options.type_latex:
         info('Generating LaTeX diff table.')
         input_files = [bm.krun_filename_changepoints for bm in benchmarks]


### PR DESCRIPTION
Fixes #13 

User now only needs to specify -l, -v and -u with CSV files.
README updated to match script.

This also enables us to create HTML results / diff tables from Krun results files.

Tested by creating diffs for both CSV and Krun files. Example debug output:

```
$ ./bin/warmup_stats --debug DEBUG --output-diff diff.html --html test-krun/before_results.json.bz2 test-krun/after_results.json.bz2 
[2018-02-15 16:13:21: DEBUG] warmup_stats script starting...
[2018-02-15 16:13:21: DEBUG] arguments: --debug DEBUG --output-diff diff.html --html test-krun/before_results.json.bz2 test-krun/after_results.json.bz2
[2018-02-15 16:13:21: INFO] Checking sanity of CLI options.
[2018-02-15 16:13:21: INFO] Checking environment.
[2018-02-15 16:13:21: INFO] Processing input files, converting to Krun JSON if necessary.
[2018-02-15 16:13:28: DEBUG] 1500 iterations per pexec in test-krun/before_results.json.bz2.
[2018-02-15 16:13:30: DEBUG] 1500 iterations per pexec in test-krun/after_results.json.bz2.
[2018-02-15 16:13:30: INFO] Checking input files.
[2018-02-15 16:13:30: INFO] Converting CSV to Krun JSON.
[2018-02-15 16:13:30: INFO] Marking outliers in JSON.
[2018-02-15 16:13:30: DEBUG] Running: /usr/bin/pypy /home/snim2/Desktop/working/softdev/warmup_stats/bin/mark_outliers_in_json -w 150 test-krun/before_results.json.bz2
[2018-02-15 16:13:58: DEBUG] Written out: test-krun/before_results_outliers_w150.json.bz2
[2018-02-15 16:13:58: DEBUG] Running: /usr/bin/pypy /home/snim2/Desktop/working/softdev/warmup_stats/bin/mark_outliers_in_json -w 150 test-krun/after_results.json.bz2
[2018-02-15 16:14:09: DEBUG] Written out: test-krun/after_results_outliers_w150.json.bz2
[2018-02-15 16:14:09: INFO] Marking changepoints in JSON.
[2018-02-15 16:14:09: DEBUG] Running: /usr/bin/python2.7 /home/snim2/Desktop/working/softdev/warmup_stats/bin/mark_changepoints_in_json -s 375 test-krun/before_results_outliers_w150.json.bz2
[2018-02-15 16:15:08: DEBUG] Written out: test-krun/before_results_outliers_w150_changepoints.json.bz2
[2018-02-15 16:15:08: DEBUG] Running: /usr/bin/python2.7 /home/snim2/Desktop/working/softdev/warmup_stats/bin/mark_changepoints_in_json -s 375 test-krun/after_results_outliers_w150.json.bz2
[2018-02-15 16:15:34: DEBUG] Written out: test-krun/after_results_outliers_w150_changepoints.json.bz2
[2018-02-15 16:15:34: INFO] Generating HTML diff table.
[2018-02-15 16:15:34: DEBUG] Running: /usr/bin/python2.7 /home/snim2/Desktop/working/softdev/warmup_stats/bin/diff_results --html diff.html --input-results test-krun/before_results_outliers_w150_changepoints.json.bz2 test-krun/after_results_outliers_w150_changepoints.json.bz2
[2018-02-15 16:23:51: DEBUG] Written out: diff.html
```

and the resulting diff:

![screenshot from 2018-02-15 16-52-33](https://user-images.githubusercontent.com/97674/36269253-a3662208-1270-11e8-938f-11161f6f5379.png)


@fsfod may be interested in this one...