### PR TITLE
Improve y-labels on instrumentation plots.

### DIFF
--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -165,6 +165,7 @@ ZOOM_OUTLIER_SIZE = 8
 TICK_FONTSIZE = 8
 TITLE_FONT_SIZE = 10
 AXIS_FONTSIZE = 8
+YAXIS_FONTSIZE = 8
 LEGEND_FONTSIZE = 10
 YTICK_FORMAT = '%.4f'
 
@@ -561,7 +562,7 @@ class ProcessExecChart(object):
             pyplot.setp(axis.get_xticklabels(), visible=False)
             y_axis = axis.get_yaxis()
             y_axis.set_tick_params(labelsize=TICK_FONTSIZE, colors=LABEL_COLOUR, zorder=ZORDER_GRID)
-        axis.set_ylabel(y_label, fontsize=AXIS_FONTSIZE, color=LABEL_COLOUR)
+        axis.set_ylabel(y_label, fontsize=YAXIS_FONTSIZE, color=LABEL_COLOUR)
         axis.yaxis.set_label_position('right')
 
     def _get_scatter_points_within_bounds(self, scatter, x_bounds):

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -60,7 +60,8 @@ from warmup.krun_results import pretty_print_machine, read_krun_results_file
 from warmup.outliers import get_window
 from warmup.plotting import add_inset_to_axis, add_margin_to_axes
 from warmup.plotting import collide_rect, compute_grid_offsets, format_yticks_scientific
-from warmup.plotting import get_unified_yrange, style_axis, STYLE_DICT, zoom_y_min, zoom_y_max
+from warmup.plotting import get_unified_yrange, style_axis, STYLE_DICT, wrap_ylabel
+from warmup.plotting import zoom_y_min, zoom_y_max
 from warmup.vm_instruments import INSTRUMENTATION_PARSERS
 
 pyplot.figure(tight_layout=True)
@@ -731,11 +732,10 @@ class ProcessExecChart(object):
             self.instr_axes[index] = pyplot.subplot(self.inner_grid[self.row, 0],
                                                     sharex=self.wallclock_axis)
             self.instr_axes[index].plot(self.iterations, idata.data[self.x_bounds[0]:self.x_bounds[1]],
-                        color=INSTR_COLOR, label=idata.title,
-                        linewidth=LINE_WIDTH, zorder=ZORDER_DATA)
+                        color=INSTR_COLOR, linewidth=LINE_WIDTH, zorder=ZORDER_DATA)
             self.instr_axes[index].set_ylim(self.instr_y_ranges[index])
             self.style_axis(self.instr_axes[index], self.instr_y_ranges[index],
-                            None, idata.title, color=INSTR_COLOR)
+                            None, wrap_ylabel(idata.title), color=INSTR_COLOR)
             if index == 0:
                 # Add all items to page legend (only once).
                 handles, labels = self.instr_axes[index].get_legend_handles_labels()

--- a/warmup/plotting.py
+++ b/warmup/plotting.py
@@ -37,6 +37,7 @@
 
 import math
 import numpy
+import textwrap
 
 from matplotlib import pyplot
 from matplotlib.ticker import ScalarFormatter, FormatStrFormatter
@@ -49,6 +50,8 @@ ZORDER_GRID = 1
 DARK_GRAY = '.15'
 LIGHT_GRAY = '.8'
 BASE_FONTSIZE = 8
+
+MAX_INSTR_YLABEL_CHARS = 12
 
 STYLE_DICT = {
     'figure.facecolor': 'white',
@@ -77,6 +80,10 @@ STYLE_DICT = {
     'pdf.fonttype': 42,
     'ps.fonttype': 42,
 }
+
+
+def wrap_ylabel(text, width=MAX_INSTR_YLABEL_CHARS):
+    return textwrap.TextWrapper(width=width).fill(text.replace('_', '\n'))
 
 
 def zoom_y_min(data, outliers, start_from=0):


### PR DESCRIPTION
This is a first go at better y-labels for instrumentation plots, here we apply word-wrapping. This may not be the best solution, but it avoids having a new CLI option.

I don't have great test data for this, so it would be helpful if someone else can give it a kicking. 

Fixes #50 