### PR TITLE
Fix issue 52

### DIFF
--- a/bin/table_classification_summaries_others
+++ b/bin/table_classification_summaries_others
@@ -66,9 +66,6 @@ def create_cli_parser():
     parser.add_argument('--outfile', '-o', action='store', dest='latex_file',
                         type=str, help='Name of the LaTeX file to write to.',
                         required=True)
-    parser.add_argument('--num-splits', '-s', action='store',
-                        type=int, help='Number of horizontal splits.',
-                        default=1)
     parser.add_argument('--without-preamble', action='store_true',
                         dest='without_preamble', default=False,
                         help='Write out only the table (for inclusion in a separate document).')
@@ -86,5 +83,5 @@ if __name__ == '__main__':
     machine, bmarks, latex_summary = convert_to_latex(summary_data, classifier['delta'], classifier['steady'])
     print('Writing data to: %s' % options.latex_file)
     write_latex_table(machine, bmarks, latex_summary, options.latex_file,
-                      options.num_splits, with_preamble=(not options.without_preamble),
+                      with_preamble=(not options.without_preamble),
                       longtable=True)

--- a/bin/warmup_stats
+++ b/bin/warmup_stats
@@ -466,11 +466,8 @@ def main(options):
     if options.output_table and options.type_latex:
         info('Generating LaTeX / PDF table.')
         machine, bmarks, latex_summary = convert_to_latex(summary, classifier['delta'], classifier['steady'])
-        num_splits = 1
-        if len(latex_summary.keys()) > 1:  # More than one VM.
-            num_splits = 2
         write_latex_table(machine, bmarks, latex_summary, options.output_table,
-                          num_splits, longtable=True, with_preamble=True)
+                          longtable=True, with_preamble=True)
         info('Compiling table as PDF.')
         cli = [pdflatex_path, '-interaction=batchmode', options.output_table]
         debug('Running: %s' % ' '.join(cli))


### PR DESCRIPTION
Please see individual commit messages.

Fixes #52 which discovered that LaTeX tables could sometimes exceed the `\textwidth` if `longtable` is used with `--num-splits > 1`.

(Assigning @ltratt because this affects CLI options relevant to both warmup and the other projects)
