### PR TITLE
Fix issue 54

### DIFF
--- a/bin/diff_results
+++ b/bin/diff_results
@@ -126,8 +126,10 @@ def fatal(message):
 
 
 def legend():
-    key = (colour_tex_cell(BETTER, 'improved'), colour_tex_cell(WORSE, 'worsened'),
-           colour_tex_cell(DIFFERENT, 'different'), colour_tex_cell(SAME, 'unchanged'))
+    key = (colour_tex_cell(BETTER, 'improved', legend=True),
+           colour_tex_cell(WORSE, 'worsened', legend=True),
+           colour_tex_cell(DIFFERENT, 'different', legend=True),
+           colour_tex_cell(SAME, 'unchanged', legend=True))
     return '\\textbf{Diff against previous results:} ' + ' '.join(key) + '.'
 
 
@@ -336,10 +338,14 @@ def diff(before_file, after_file, summary_filename):
     return summary
 
 
-def colour_tex_cell(result, text):
+def colour_tex_cell(result, text, legend=False):
     """Colour a table cell containing `text` according to `result`."""
 
     assert result in (None, SAME, DIFFERENT, BETTER, WORSE)
+    if legend:
+        cmd = 'legendcell'
+    else:
+        cmd = 'ccell'
     if not text or result is None or result == SAME:
         return text
     if result == BETTER:
@@ -348,7 +354,7 @@ def colour_tex_cell(result, text):
         colour = 'lightred'
     else:
         colour = 'lightyellow'
-    return '\\ccell{%s}{%s}' % (colour, text)
+    return '\\%s{%s}{%s}' % (cmd, colour, text)
 
 
 def write_latex_table(machine, all_benchs, summary, diff, tex_file, num_splits,

--- a/bin/diff_results
+++ b/bin/diff_results
@@ -460,7 +460,7 @@ def write_latex_table(machine, all_benchs, summary, diff, tex_file, num_splits,
                     vm_idx += 1
                 fp.write('&'.join(row))
                 # Only -ve space row if not next to a midrule
-                if bench_idx < num_vms - 1:
+                if not longtable and bench_idx < num_vms - 1:
                     fp.write('\\\\[-3pt] \n')
                 else:
                     fp.write('\\\\ \n')

--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -167,7 +167,20 @@ $\\begin{array}{rr}
 }
 \\def\\@ccell#1#2#3{%
    \\tcbox[tcbox raise base,left=0mm,right=0mm,top=0mm,bottom=0mm,%
-           boxsep=0.5pt,arc=0mm,boxrule=0pt,opacityfill=0.3,enhanced jigsaw,%
+           boxsep=0pt,arc=0mm,boxrule=0pt,opacityfill=0.3,enhanced jigsaw,%
+           colback=#2!85!white]{#3}
+}
+\\makeatother
+%
+% Coloured cells for legends (do not force a newline after the box).
+%
+\\makeatletter
+\\protected\\def\\legendcell#1#{%
+  \\@legendcell{#1}%
+}
+\\def\\@legendcell#1#2#3{%
+   \\tcbox[tcbox raise base,left=0mm,right=0mm,top=0mm,bottom=0mm,%
+           boxsep=0pt,arc=0mm,boxrule=0pt,opacityfill=0.3,enhanced jigsaw,%
            colback=#2!85!white,before=\\relax,after=\\relax]{#3}
 }
 \\makeatother

--- a/warmup/summary_statistics.py
+++ b/warmup/summary_statistics.py
@@ -409,7 +409,7 @@ def write_latex_table(machine, all_benchs, summary, tex_file, with_preamble=Fals
                 row.extend(row_add)
                 fp.write('&'.join(row))
                 # Only -ve space row if not next to a midrule
-                if bench_idx < num_vms - 1:
+                if not longtable and bench_idx < num_vms - 1:
                     fp.write('\\\\[-3pt] \n')
                 else:
                     fp.write('\\\\ \n')


### PR DESCRIPTION
Fixes #54 

This turns out to be two bugs, so it needs two test cases...

Diff table before (pp2 better example than pp1): [old-diff.pdf](https://github.com/softdevteam/warmup_stats/files/1971285/old-diff.pdf)
Diff table after: [new-diff.pdf](https://github.com/softdevteam/warmup_stats/files/1971287/new-diff.pdf)

Normal table before: [old-table.pdf](https://github.com/softdevteam/warmup_stats/files/1971276/old-table.pdf)
Normal table after: [new-table.pdf](https://github.com/softdevteam/warmup_stats/files/1971279/new-table.pdf)
