### PR TITLE
Do not build if lsb_release is not installed.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,7 @@
   * R (version 3.3.1 or later)
   * readline (including header files)
   * wget
+  * lsb-release (needed on Ubuntu systems)
 
 ## Optional requirements
 
@@ -34,8 +35,8 @@ Debian-based systems:
 $ sudo apt-get install build-essential python2.7 pypy bzip2 libssl-dev \
        pkg-config libcurl4-openssl-dev python-numpy python-matplotlib \
        python-pip texlive-latex-extra wget python2.7-dev libreadline-dev \
-       libbz2-dev liblzma-dev libpcre3-dev gfortran r-base
-$ ./build_stats.sh
+       libbz2-dev liblzma-dev libpcre3-dev gfortran r-base lsb-release
+$ ./build.sh
 ```
 
 ## Setting up R


### PR DESCRIPTION
This is not needed by the bin/ scripts, but the build script uses it to determine the Debian version (in order to pass correct CLI arguments to pip).

Fixes #77 