### PR TITLE
Use colortbl for coloured LaTeX tables.

### DIFF
--- a/bin/diff_results
+++ b/bin/diff_results
@@ -110,8 +110,8 @@ CLASSIFIER = 'classifier'
 DIFF = 'diff'
 # LaTeX output.
 TITLE = 'Summary of benchmark classifications'
-TABLE_FORMAT = ('ll@{\hspace{0cm}}ll@{\hspace{-1cm}}r@{\hspace{0cm}}r@{\hspace{0cm}}r@{\hspace{0cm}}r@{\hspace{0cm}}'
-                'l@{\hspace{.3cm}}ll@{\hspace{-1cm}}r@{\hspace{0cm}}r@{\hspace{0cm}}rr@{\hspace{0cm}}r')
+TABLE_FORMAT = ('ll@{\hspace{0cm}}ll@{\hspace{0cm}}r@{\hspace{.4cm}}r@{\hspace{.4cm}}r@{\hspace{.4cm}}r@{\hspace{.4cm}}'
+                'l@{\hspace{.4cm}}ll@{\hspace{.4cm}}r@{\hspace{.4cm}}r@{\hspace{.4cm}}rr@{\hspace{.4cm}}r')
 TABLE_HEADINGS_START1 = '\\multicolumn{1}{c}{\\multirow{2}{*}{}}&'
 TABLE_HEADINGS_START2 = '&'
 TABLE_HEADINGS1 = ('&&\\multicolumn{1}{c}{} &\\multicolumn{1}{c}{Steady} &\\multicolumn{1}{c}{Steady iter.} '
@@ -128,11 +128,14 @@ def fatal(message):
 
 
 def legend():
-    key = (colour_tex_cell(BETTER, 'improved', legend=True),
-           colour_tex_cell(WORSE, 'worsened', legend=True),
-           colour_tex_cell(DIFFERENT, 'different', legend=True),
-           colour_tex_cell(SAME, 'unchanged', legend=True))
-    return '\\textbf{Diff against previous results:} ' + ' '.join(key) + '.'
+    table = """\\begin{tabular}{l|l|l|l}
+\\multicolumn{1}{c}{%s} & \\multicolumn{1}{c}{%s} & \\multicolumn{1}{c}{%s} & \\multicolumn{1}{c}{%s} \\\\
+\\end{tabular}
+""" % (colour_tex_cell(BETTER, 'improved'),
+       colour_tex_cell(WORSE, 'worsened'),
+       colour_tex_cell(DIFFERENT, 'different'),
+       colour_tex_cell(SAME, 'unchanged'))
+    return '\\textbf{Diff against previous results:} ' + table
 
 
 def do_intervals_differ((x1, y1), (x2, y2)):
@@ -393,16 +396,10 @@ def diff(before_file, after_file, summary_filename):
     return summary
 
 
-def colour_tex_cell(result, text, large=False, legend=False):
+def colour_tex_cell(result, text):
     """Colour a table cell containing `text` according to `result`."""
 
     assert result in (None, SAME, DIFFERENT, BETTER, WORSE)
-    if legend:
-        cmd = 'legendcell'
-    elif large:
-        cmd = 'largeccell'
-    else:
-        cmd = 'ccell'
     if not text or result is None or result == SAME:
         return text
     if result == BETTER:
@@ -411,7 +408,7 @@ def colour_tex_cell(result, text, large=False, legend=False):
         colour = 'lightred'
     else:
         colour = 'lightyellow'
-    return '\\%s{%s}{%s}' % (cmd, colour, text)
+    return '\\cellcolor{%s!25}{%s}' % (colour, text)
 
 
 def write_latex_table(machine, all_benchs, summary, diff, tex_file, num_splits,
@@ -476,8 +473,7 @@ def write_latex_table(machine, all_benchs, summary, diff, tex_file, num_splits,
                         if vm in diff and bench in diff[vm]:
                             classification = colour_tex_cell(diff[vm][bench][CLASSIFICATIONS], this_summary['style'])
                             last_cpt = colour_tex_cell(diff[vm][bench][STEADY_ITER], this_summary['last_cpt'])
-                            steady_iter_var = colour_tex_cell(diff[vm][bench][STEADY_ITER_VAR],
-                                                              this_summary['steady_iter_var'], large=True)
+                            steady_iter_var = colour_tex_cell(diff[vm][bench][STEADY_ITER_VAR], this_summary['steady_iter_var'])
                             time_steady = colour_tex_cell(diff[vm][bench][STEADY_ITER], this_summary['time_to_steady_state'])
                             last_mean = colour_tex_cell(diff[vm][bench][STEADY_STATE_TIME], this_summary['last_mean'])
                             steady_time_var = colour_tex_cell(diff[vm][bench][STEADY_STATE_TIME_VAR], this_summary['steady_time_var'])

--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -66,12 +66,14 @@ __MACROS = """
 %
 % blankheight.
 %
+\\AtBeginDocument{
 \\newlength{\\blankheight}
 \\settototalheight{\\blankheight}{
 $\\begin{array}{rr}
 \\scriptstyle{0.16} \\\\[-6pt]
 \\scriptscriptstyle{\\pm0.000}
 \\end{array}$
+}
 }
 
 
@@ -158,50 +160,6 @@ $\\begin{array}{rr}
 \\end{sparkline}\\xspace}
 
 %
-% Coloured table cells.
-% We don't use colortbl or [table]xcolor because it causes a compiler error
-% on our table headers.
-% https://tex.stackexchange.com/questions/360461/get-a-transparent-nestable-wrappable-background
-%
-\\makeatletter
-\\protected\\def\\ccell#1#{%
-  \\@ccell{#1}%
-}
-\\def\\@ccell#1#2#3{%
-   \\tcbox[tcbox raise base,left=0mm,right=0mm,top=0mm,bottom=0mm,%
-           boxsep=0pt,arc=0mm,boxrule=0pt,opacityfill=0.3,enhanced jigsaw,%
-           colback=#2!85!white]{#3}
-}
-\\makeatother
-
-\\makeatletter
-\\protected\\def\\largeccell#1#{%
-  \\@largeccell{#1}%
-}
-\\def\\@largeccell#1#2#3{%
-   \\tcbox[tcbox raise base,left=0mm,right=0mm,top=0mm,bottom=2mm,%
-           boxsep=0pt,arc=0mm,boxrule=0pt,opacityfill=0.3,enhanced jigsaw,%
-           colback=#2!85!white]{#3}
-}
-\\makeatother
-
-%
-% Coloured cells for legends (do not force a newline after the box).
-% We don't use colortbl or [table]xcolor because it causes a compiler error
-% on our table headers.
-%
-\\makeatletter
-\\protected\\def\\legendcell#1#{%
-  \\@legendcell{#1}%
-}
-\\def\\@legendcell#1#2#3{%
-   \\tcbox[tcbox raise base,left=0mm,right=0mm,top=0mm,bottom=0mm,%
-           boxsep=0pt,arc=0mm,boxrule=0pt,opacityfill=0.3,enhanced jigsaw,%
-           colback=#2!85!white,before=\\relax,after=\\relax]{#3}
-}
-\\makeatother
-
-%
 % Colours.
 %
 \\definecolor{lightred}{HTML}{e88a8a}
@@ -218,6 +176,7 @@ __LATEX_PREAMBLE = lambda title, doc_opts=DEFAULT_DOCOPTS: """
 \\usepackage{amssymb}
 \\usepackage{booktabs}
 \\usepackage{calc}
+\\usepackage{colortbl}
 \\usepackage[margin=1.0cm]{geometry}
 \\usepackage{longtable}
 \\usepackage{mathtools}
@@ -226,8 +185,6 @@ __LATEX_PREAMBLE = lambda title, doc_opts=DEFAULT_DOCOPTS: """
 \\usepackage{pdflscape}
 \\usepackage{rotating}
 \\usepackage{sparklines}
-\\usepackage{tcolorbox}
-\\tcbuselibrary{most}
 \\usepackage{xspace}
 
 

--- a/warmup/summary_statistics.py
+++ b/warmup/summary_statistics.py
@@ -321,12 +321,12 @@ def convert_to_latex(summary_data, delta, steady_state, diff=None, previous=None
                                                bmark['steady_state_time_ci'],
                                                bmark['steady_state_time_list'],
                                                change=change)
-            if diff and diff[vm][bmark_name] and diff[vm][bmark_name][STEADY_STATE_TIME_VAR] is not None:
-                change = abs(bmark['steady_state_time_ci'] - previous['machines'][machine][vm][bmark_name]['steady_state_time_ci'])
-                steady_time_var = format_median_ci(bmark['steady_state_time_ci'],
-                                                   bmark['steady_state_time_ci'],
-                                                   None,
-                                                   change=change)
+                if diff and diff[vm][bmark_name] and diff[vm][bmark_name][STEADY_STATE_TIME_VAR] is not None:
+                    change = abs(bmark['steady_state_time_ci'] - previous['machines'][machine][vm][bmark_name]['steady_state_time_ci'])
+                    steady_time_var = format_median_ci(bmark['steady_state_time_ci'],
+                                                       bmark['steady_state_time_ci'],
+                                                       None,
+                                                       change=change)
             else:
                 mean_steady = ''
             if bmark['steady_state_time_to_reach_secs'] is not None:


### PR DESCRIPTION
This package allows us to colour individual table cells, and (unlike our own attempts to do this) correctly sizes each cell. This makes diff tables considerably neater and easier to read.

In addition, the resulting code is much simpler.

Master branch: [why_green_master.pdf](https://github.com/softdevteam/warmup_stats/files/2388441/why_green_master.pdf)

Feature branch: [why_green_better.pdf](https://github.com/softdevteam/warmup_stats/files/2388438/why_green_better.pdf)

Fixes #83
