### PR TITLE
Allow users to diff two VMs

### DIFF
--- a/bin/diff_results
+++ b/bin/diff_results
@@ -42,6 +42,7 @@ Plot a chart describing the effect of re-running an experiment with fewer iterat
 MUST be run after generate_truncated_json.
 """
 
+import collections
 import math
 import os
 import sys
@@ -207,7 +208,25 @@ def any_nss(classifications):
     return classifications['no steady state'] > 0
 
 
-def diff(before_file, after_file, summary_filename):
+def _rewrite_key(key, diff_vms):
+    """Rewrite a bench:vm:language key.
+    Takes as arguments one key, and a list of two VM names, that the user wants
+    to compare - ['VM1', 'VM2']. Rewrites the key from 'bench:vm:language' to
+    'bench:VM1 vs. VM2:language'.
+
+    By default, the differ compares all VMs that appear in one results file
+    against results from the same the same VM in a second file. When the user
+    wants to compare one VM against another, this renaming fools the differ
+    into thinking that the two different VMs are the same. We choose the name
+    'VM1 vs. VM2' since that is the text we wish to appear in the output tables.
+    """
+
+    split = key.split(':')
+    combined_vm = ' vs. '.join(diff_vms)
+    return ':'.join([split[0], combined_vm, split[2]])
+
+
+def diff(before_file, after_file, summary_filename, diff_vms=[]):
     """Diff results in before_file and after_file."""
 
     classifiers = dict()
@@ -217,20 +236,49 @@ def diff(before_file, after_file, summary_filename):
     summary = {DIFF: dict(), BEFORE: None, AFTER: None, CLASSIFIER: None}
     print('Loading %s.' % before_file)
     classifiers[BEFORE], before_results = parse_krun_file_with_changepoints([before_file])
-    summary[BEFORE] = collect_summary_statistics(before_results,
-                                                 classifiers[BEFORE]['delta'], classifiers[BEFORE]['steady'])
     print('Loading %s.' % after_file)
     classifiers[AFTER], after_results = parse_krun_file_with_changepoints([after_file])
+    assert len(before_results.keys()) == 1, 'Expected one machine per results file.'
+    assert len(after_results.keys()) == 1, 'Expected one machine per results file.'
+    assert before_results.keys()[0] == after_results.keys()[0], 'Expected results to be from same machine.'
+    machine = before_results.keys()[0]
+    # Special case: the user wants to diff one VM against another (by default,
+    # we diff each VM against itself, for every VM that appears in both the
+    # before and after data). If the user wants to diff one VM against another,
+    # then we rename the "before" and "after" VMs to these special names, and
+    # rename them back before presenting the diff results back to the user. This
+    # is an unpleasant hack, but since the diff information is baked into the
+    # structure of the summary diff, improving this code (and the LaTeX / HTML
+    # output code) would be a significant task.
+    if diff_vms:
+        before_vm, after_vm = diff_vms
+        found_before_vm, found_after_vm =  False, False
+        for dtype in before_results[machine]:
+            if isinstance(before_results[machine][dtype], collections.Iterable):
+                for key in before_results[machine][dtype]:
+                    if before_vm in key:
+                        found_before_vm = True
+                        new_key = _rewrite_key(key, diff_vms)
+                        before_results[machine][dtype][new_key] = before_results[machine][dtype].pop(key)
+        if not found_before_vm:
+             fatal('Could not find requested VM in results data: ' + before_vm)
+        for dtype in after_results[machine]:
+            if isinstance(after_results[machine][dtype], collections.Iterable):
+                for key in after_results[machine][dtype]:
+                    if after_vm in key:
+                        found_after_vm = True
+                        new_key = _rewrite_key(key, diff_vms)
+                        after_results[machine][dtype][new_key] = after_results[machine][dtype].pop(key)
+        if not found_after_vm:
+             fatal('Could not find requested VM in results data: ' + after_vm)
+    summary[BEFORE] = collect_summary_statistics(before_results,
+                                                 classifiers[BEFORE]['delta'], classifiers[BEFORE]['steady'])
     summary[AFTER] = collect_summary_statistics(after_results,
                                                 classifiers[AFTER]['delta'], classifiers[AFTER]['steady'])
     for key in classifiers[BEFORE]:
         assert classifiers[BEFORE][key] == classifiers[AFTER][key], \
             'Results files generated with different values for %s' % key
     summary[CLASSIFIER] = classifiers[AFTER]
-    assert len(before_results.keys()) == 1, 'Expected one machine per results file.'
-    assert len(after_results.keys()) == 1, 'Expected one machine per results file.'
-    assert before_results.keys()[0] == after_results.keys()[0], 'Expected results to be from same machine.'
-    machine = before_results.keys()[0]
     # Generate CIs for DEFAULT_ITER classification data.
     before_class_cis = dict()
     for key in before_results[machine]['classifications']:
@@ -412,7 +460,7 @@ def colour_tex_cell(result, text):
 
 
 def write_latex_table(machine, all_benchs, summary, diff, tex_file, num_splits,
-                      with_preamble=False, longtable=False):
+                      with_preamble=False, longtable=False, diff_vms=[]):
     """Write a tex table to disk"""
 
     num_benchmarks = len(all_benchs)
@@ -438,6 +486,9 @@ def write_latex_table(machine, all_benchs, summary, diff, tex_file, num_splits,
     with open(tex_file, 'w') as fp:
         if with_preamble:
             fp.write(preamble(TITLE))
+            if diff_vms:
+                fp.write('\\centering{%%\n\\Large{\\textbf{%s vs. %s}}%%\n}\n\\\\\n~\\\\\n\n'
+                         % (diff_vms[0], diff_vms[1]))
             legends = get_latex_symbol_map() + ' \\\\ ' + legend()
             fp.write('\\centering %s' % legends)
             fp.write('\n\n\n')
@@ -553,7 +604,17 @@ def create_cli_parser():
                         type=int, help='Number of horizontal splits (LaTeX only).')
     parser.add_argument('--without-preamble', action='store_true',
                         dest='without_preamble', default=False,
-                        help='Write out only a LaTeX table, for inclusion in a larger document.')
+                        help='Write out only a LaTeX table, for inclusion in a\nlarger document.')
+    parser.add_argument('--vm', action='append', nargs=2, dest='vm', default=[],
+                         help='Compare one VM against another. \nRequires two '
+                              'VM names as arguments. By default, the\ndiffer '
+                              'will compare all benchmarks / VMs which appear\n'
+                              'in both input files. Users should be aware that this\n'
+                              'option produces a summary file with some special JSON\n'
+                              'keys. This means that summary files (usually\ndiff_summary.json) '
+                              'usually not be suitable for\ngenerating generic diff tables, or '
+                              'tables with different\n--vm options. In this case, users should '
+                              'regenerate the\nsummary file with the original data and the -r option.')
     outputs = parser.add_mutually_exclusive_group(required=True)
     outputs.add_argument('--tex', action='store', type=str,
                          help='LaTeX file in which to write diff summary.')
@@ -561,10 +622,10 @@ def create_cli_parser():
                          help='HTML file in which to write diff summary.')
     inputs = parser.add_mutually_exclusive_group(required=True)
     inputs.add_argument('-s', '--input-summary', action='store', default=None,
-                        type=str, help=('Read summary data from JSON file rather than '
-                                        'generating from a two original results files.'))
+                        type=str, help='Read summary data from JSON file rather than '
+                                       'generating\nfrom two original results files.')
     inputs.add_argument('-r', '--input-results', nargs=2, action='append', default=[], type=str,
-                        help='Exactly two Krun result files (with outliers and changepoints).')
+                        help='Exactly two Krun result files (with outliers and\nchangepoints).')
     return parser
 
 
@@ -587,7 +648,12 @@ if __name__ == '__main__':
         if '_changepoints' not in options.input_results[0][1]:
             fatal('Please run mark_changepoints_in_json on file %s before diffing.' %
                   options.input_results[0][1])
-        diff_summary = diff(options.input_results[0][0], options.input_results[0][1], options.json)
+        if options.vm:
+            diff_summary = diff(options.input_results[0][0], options.input_results[0][1],
+                                options.json, diff_vms=options.vm[0])
+        else:
+            diff_summary = diff(options.input_results[0][0], options.input_results[0][1],
+                                options.json, diff_vms=[])
     else:
         with open(options.input_summary, 'r') as fd:
             diff_summary = json.load(fd)
@@ -602,6 +668,12 @@ if __name__ == '__main__':
                                                           classifier['steady'], diff=diff_summary[DIFF],
                                                           previous=diff_summary[BEFORE])
         print('Writing data to: %s' % options.tex)
-        write_latex_table(machine, bmarks, latex_summary, diff_summary[DIFF], options.tex,
-                          options.num_splits, with_preamble=(not options.without_preamble),
-                          longtable=True)
+        if options.vm:
+            write_latex_table(machine, bmarks, latex_summary, diff_summary[DIFF], options.tex,
+                              options.num_splits, with_preamble=(not options.without_preamble),
+                              longtable=True, diff_vms=options.vm[0])
+        else:
+            write_latex_table(machine, bmarks, latex_summary, diff_summary[DIFF], options.tex,
+                              options.num_splits, with_preamble=(not options.without_preamble),
+                              longtable=True)
+

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -1256,35 +1256,19 @@ def create_cli_parser():
                     ' results.json.bz2\n') %
                    (script, script, script))
     parser = argparse.ArgumentParser(description)
-    parser.add_argument('json_files',
-                        nargs='+',
-                        action='append',
-                        default=[],
-                        type=str,
-                        help='One or more Krun result files.')
-    parser.add_argument('--instr-dir',
-                        action='store',
-                        default=None,
-                        type=str,
+    parser.add_argument('json_files', nargs='+', action='append', default=[],
+                        type=str, help='One or more Krun result files.')
+    parser.add_argument('--instr-dir', action='store', default=None, type=str,
                         help='A directory containing VM instrumentation data.')
-    parser.add_argument('--outfile', '-o',
-                        action='store',
-                        dest='outfile',
-                        default=None,
-                        type=str,
+    parser.add_argument('--outfile', '-o', action='store', dest='outfile',
+                        default=None, type=str,
                         help=('Name of the PDF file to write to. If no file is '
                               'specified, charts will be displayed interactively '
                               'and not written to disk.'))
-    parser.add_argument('--wallclock-only',
-                        action='store_true',
-                        dest='wallclock',
-                        default=False,
-                        help='Only plot wallclock times.')
-    parser.add_argument('--benchmark', '-b',
-                        action='append',
-                        dest='benchmarks',
-                        default=[],
-                        type=str,
+    parser.add_argument('--wallclock-only', action='store_true', dest='wallclock',
+                        default=False, help='Only plot wallclock times.')
+    parser.add_argument('--benchmark', '-b', action='append', dest='benchmarks',
+                        default=[], type=str,
                         help='Only draw charts for specific '
                              'machine:benchmark:vm:variant:pexec quintuplet(s). '
                              'e.g. "-b mc1.example.com:binarytrees:Hotspot:default-java:0. '
@@ -1293,85 +1277,58 @@ def create_cli_parser():
                              'VM, as measured on machine mc1. '
                              'This switch can be used repeatedly to chart '
                              'a number of benchmarks.')
-    parser.add_argument('--one-page',
-                        action='store_true',
-                        dest='one_page',
-                        default=False,
-                        help='Place all charts on a single page')
-    parser.add_argument('--xlimits', '-x',
-                        action='store',
-                        dest='xlimits',
-                        default=None,
-                        type=str,
-                        help="Specify X-axis limits as a comma separated pair "
-                             "'start,end'. Samples start from 0. e.g. "
-                             "'-x 100,130' will show samples in the range "
-                             "100 to 130.")
-    parser.add_argument('--no-inset',
-                        action='store_true',
-                        dest='inset',
-                        default=False,
+    parser.add_argument('--one-page', action='store_true', dest='one_page',
+                        default=False, help='Place all charts on a single page')
+    parser.add_argument('--xlimits', '-x', action='store', dest='xlimits',
+                        default=None, type=str,
+                        help='Specify X-axis limits as a comma separated pair '
+                             '\'start,end\'. Samples start from 0. e.g. '
+                             '\'-x 100,130\' will show samples in the range '
+                             '100 to 130.')
+    parser.add_argument('--no-inset', action='store_true', dest='inset', default=False,
                         help='Do not place a small chart plotting the first few '
                              'values of each process execution in an thumbnail '
                              'inside each plot. The inset is intended to make it '
                              'easier to see detail during the warm-up phase of '
                              'each benchmark. Insets will not be drawn over '
                              'data measurements.')
-    parser.add_argument('--no-zoom',
-                        action='store_true',
-                        dest='zoom',
-                        default=False,
+    parser.add_argument('--no-zoom', action='store_true', dest='zoom', default=False,
                         help='Do not render a small chart showing a "zoomed in" '
                              'view of your measurements. This chart is intended '
                              'to show more detail in the "fast" iterations of '
                              'benchmarks with good warmup behaviour. ')
-    parser.add_argument('--with-outliers',
-                        action='store_true',
-                        dest='outliers',
+    parser.add_argument('--with-outliers', action='store_true', dest='outliers',
                         default=False,
                         help='Annotate outliers. Only use this if your '
                              'Krun results file contains outlier information.')
-    parser.add_argument('--with-unique-outliers',
-                        action='store_true',
-                        dest='unique_outliers',
-                        default=False,
+    parser.add_argument('--with-unique-outliers', action='store_true',
+                        dest='unique_outliers', default=False,
                         help='Annotate outliers common to multiple '
                              'executions and those unique to single '
                              'executions differently. Only use this if '
                              'your Krun results file contains outlier '
                              'information.')
-    parser.add_argument('--with-changepoints',
-                        action='store_true',
-                        dest='changepoint_means',
-                        default=False,
+    parser.add_argument('--with-changepoints', action='store_true',
+                        dest='changepoint_means', default=False,
                         help='Annotate changepoints and their means as vertical '
                              'and horizontal lines. Only use this if your Krun '
                              'results file contains changepoint information.')
-    parser.add_argument('--export-size',
-                        action='store',
-                        default='12, 10',
-                        help="Set the total size (comma separated pair, "
-                             "in inches) of each process execution's "
-                             "plots in the output.")
-    parser.add_argument('--cycles-ylimits',
-                        action='store',
-                        default=None,
-                        help="Set the y-axis range for core cycle plots "
-                             "(comma separated pair)")
-    parser.add_argument('--core-cycles',
-                        action='store',
-                        dest='core_cycles',
+    parser.add_argument('--export-size', action='store', default='12, 10',
+                        help='Set the total size (comma separated pair, '
+                             'in inches) of each process execution\'s '
+                             'plots in the output.')
+    parser.add_argument('--cycles-ylimits', action='store', default=None,
+                        help='Set the y-axis range for core cycle plots '
+                             '(comma separated pair)')
+    parser.add_argument('--core-cycles', action='store', dest='core_cycles',
                         default=None,
                         help='Only plot the core cycles for specified cores '
                              '(comma separated). e.g: 0,1,2,3 or "" for no '
                              'plots. If this argument is not set, the default '
                              'behaviour is to plot as much data as is found in '
                              'the input files.')
-    parser.add_argument('--inset-xlimits', '-X',
-                        action='store',
-                        dest='inset_xlimits',
-                        default=None,
-                        type=str,
+    parser.add_argument('--inset-xlimits', '-X', action='store', dest='inset_xlimits',
+                        default=None, type=str,
                         help='Similar to --xlimits, but for thumbnail plots.')
     return parser
 

--- a/bin/warmup_stats
+++ b/bin/warmup_stats
@@ -158,6 +158,11 @@ def create_arg_parser():
     parser.add_argument('--instr-dir', dest='instr_dir', action='store', default='',
                         type=str, help=('Directory containing instrumentation data. '
                                         'Only useful when generating plots.'))
+    parser.add_argument('--diff-vms', action='append', nargs=2, dest='diff_vms', default=[],
+                         help='Compare one VM against another. \nRequires two '
+                              'VM names as arguments. By default, the\ndiffer '
+                              'will compare all benchmarks / VMs which appear\n'
+                              'in both input files.\nOnly makes sense with --output-diff.')
     # What output file format should be generated?
     format_group = parser.add_mutually_exclusive_group(required=False)
     format_group.add_argument('--html', dest='type_html', action='store_true', default=False,
@@ -359,6 +364,8 @@ def main(options):
         fatal('--output-table must be used with either --html or --tex.')
     if options.output_diff and not (options.type_latex or options.type_html):
         fatal('--output-diff must be used with either --html or --tex.')
+    if options.diff_vms and not options.output_diff:
+        fatal('--diff-vms must be used with --output-diff.')
     input_files = options.input_files[0]
     for filename in input_files:
         if filename.endswith('.csv'):
@@ -407,8 +414,13 @@ def main(options):
         info('Generating LaTeX diff table.')
         input_files = [bm.krun_filename_changepoints for bm in benchmarks]
         assert len(input_files) == 2
-        cli = [python_path, SCRIPT_DIFF_RESULTS, '--tex', options.output_diff,
-               '--input-results', ' '.join(input_files)]
+        if options.diff_vms:
+            cli = [python_path, SCRIPT_DIFF_RESULTS, '--tex', options.output_diff,
+                   '--input-results', ' '.join(input_files), '--vm',
+                   options.diff_vms[0][0], options.diff_vms[0][1]]
+        else:
+            cli = [python_path, SCRIPT_DIFF_RESULTS, '--tex', options.output_diff,
+                   '--input-results', ' '.join(input_files)]
         debug('Running: %s' % ' '.join(cli))
         output = subprocess.check_output(' '.join(cli), shell=True)
         for line in output.strip().split('\n'):
@@ -423,8 +435,13 @@ def main(options):
         info('Generating HTML diff table.')
         input_files = [bm.krun_filename_changepoints for bm in benchmarks]
         assert len(input_files) == 2
-        cli = [python_path, SCRIPT_DIFF_RESULTS, '--html', options.output_diff,
-               '--input-results', ' '.join(input_files)]
+        if options.diff_vms:
+            cli = [python_path, SCRIPT_DIFF_RESULTS, '--html', options.output_diff,
+                       '--input-results', ' '.join(input_files), '--vm',
+                       options.diff_vms[0][0], options.diff_vms[0][1]]
+        else:
+            cli = [python_path, SCRIPT_DIFF_RESULTS, '--html', options.output_diff,
+                   '--input-results', ' '.join(input_files)]
         debug('Running: %s' % ' '.join(cli))
         output = subprocess.check_output(' '.join(cli), shell=True)
         for line in output.strip().split('\n'):

--- a/warmup/summary_statistics.py
+++ b/warmup/summary_statistics.py
@@ -350,7 +350,8 @@ def convert_to_latex(summary_data, delta, steady_state, diff=None, previous=None
     return machine, list(sorted(benchmark_names)), latex_summary
 
 
-def write_latex_table(machine, all_benchs, summary, tex_file, with_preamble=False, longtable=False):
+def write_latex_table(machine, all_benchs, summary, tex_file, with_preamble=False,
+                      longtable=False):
     """Write a tex table to disk.
     This is NOT used to create diff tables or the tables for the warmup
     experiment (a separate script in the other repo exists for that). However,


### PR DESCRIPTION
By default, the stats differ assumes that the user is working on one VM, and wishes to diff its benchmark results to determine whether a recent change in the VM has resulted in an improvement.

This PR adds another use case: where the user wishes to diff one VM against another. We cheat slightly, by simply renaming both VMs to the text we wish to see on the page `VM1 vs. VM2`.

Fixes #71 

In addition, since we're messing with CLI options, I've tidied (i.e. improved whitespace) the CLI options in the plotting script.

It's probably worth adding that Issue #89 is related to this one -- i.e. if the user diffs one VM against another, but one VM skipped a benchmark that the other executed, the diff script currently crashes. A later PR will fix this.