### PR TITLE
Only say that CIs have narrowed if it exceeds a certain threshold.

### DIFF
--- a/bin/diff_results
+++ b/bin/diff_results
@@ -91,6 +91,7 @@ Example usage (input JSON summary file, output LaTeX):
 """
 
 ALPHA = 0.01  # Significance level.
+CI_MINIUM_SIGNIFICANT_NARROWING = 0.0001 # In seconds
 CATEGORIES = ['warmup', 'slowdown', 'flat', 'no steady state']
 MCI = rpy2.interactive.packages.importr('MultinomialCI')
 # List indices (used in favour of dictionary keys).
@@ -120,8 +121,8 @@ TABLE_HEADINGS_START1 = '\\multicolumn{1}{c}{\\multirow{2}{*}{}}&'
 TABLE_HEADINGS_START2 = '&'
 TABLE_HEADINGS1 = ('&&\\multicolumn{1}{c}{} &\\multicolumn{1}{c}{Steady} &\\multicolumn{1}{c}{Steady iter.} '
                    '&\\multicolumn{1}{c}{Steady} &\\multicolumn{1}{c}{Steady} &\\multicolumn{1}{c}{Steady perf.}')
-TABLE_HEADINGS2 = ('&&\\multicolumn{1}{c}{Class.} &\\multicolumn{1}{c}{iter (\#)} &\\multicolumn{1}{c}{variation} '
-                   '&\\multicolumn{1}{c}{iter (s)} &\\multicolumn{1}{c}{perf (s)} &\\multicolumn{1}{c}{variation}')
+TABLE_HEADINGS2 = ('&&\\multicolumn{1}{c}{Class.} &\\multicolumn{1}{c}{iter (\#)} &\\multicolumn{1}{c}{variation (s)} '
+                   '&\\multicolumn{1}{c}{iter (s)} &\\multicolumn{1}{c}{perf (s)} &\\multicolumn{1}{c}{variation (s)}')
 
 JSON_VERSION_NUMBER = '2'
 
@@ -184,6 +185,8 @@ def does_ci_narrow(mean1, ci1, mean2, ci2):
     """Return True if the second interval is narrower than the first."""
 
     assert ci1 >= 0.0 and ci2 >= 0.0, 'Found negative confidence interval from bootstrapping.'
+    if abs(ci1 - ci2) < CI_MINIUM_SIGNIFICANT_NARROWING:
+        return SAME
     x1 = mean1 - ci1
     y1 = mean1 + ci1
     x2 = mean2 - ci2

--- a/warmup/html.py
+++ b/warmup/html.py
@@ -92,8 +92,8 @@ HTML_TABLE_TEMPLATE = """<h2>Results for %s</h2>
 <th>Benchmark</th>
 <th>Classification</th>
 <th>Steady iteration (&#35;)</th>
-<th>Steady iteration (secs)</th>
-<th>Steady performance (secs)</th>
+<th>Steady iteration (s)</th>
+<th>Steady performance (s)</th>
 </tr>
 %s
 </table>
@@ -107,9 +107,9 @@ HTML_DIFF_TABLE_TEMPLATE = """<h2>Results for %s</h2>
 <th>Classification</th>
 <th>Steady iteration (&#35;)</th>
 <th>Steady iteration variation</th>
-<th>Steady iteration (secs)</th>
-<th>Steady performance (secs)</th>
-<th>Steady performance variation</th>
+<th>Steady iteration (s)</th>
+<th>Steady performance (s)</th>
+<th>Steady performance variation (s)</th>
 </tr>
 %s
 </table>

--- a/warmup/summary_statistics.py
+++ b/warmup/summary_statistics.py
@@ -329,10 +329,7 @@ def convert_to_latex(summary_data, delta, steady_state, diff=None, previous=None
                                                change=change)
                 if diff and diff[vm][bmark_name] and diff[vm][bmark_name][STEADY_STATE_TIME_VAR] is not None:
                     change = abs(bmark['steady_state_time_ci'] - previous['machines'][machine][vm][bmark_name]['steady_state_time_ci'])
-                    steady_time_var = format_median_ci(bmark['steady_state_time_ci'],
-                                                       bmark['steady_state_time_ci'],
-                                                       None,
-                                                       change=change)
+                    steady_time_var = "$\\begin{array}{c}\\scriptstyle{%.5f}\\\\[-6pt]\n\\scriptscriptstyle{was: %.5f}\n\\end{array}$" % (bmark['steady_state_time_ci'], previous['machines'][machine][vm][bmark_name]['steady_state_time_ci'])
             else:
                 mean_steady = ''
             if bmark['steady_state_time_to_reach_secs'] is not None:
@@ -594,9 +591,9 @@ def write_html_table(summary_data, html_filename, diff=None, skipped=None, previ
                 if diff and vm in diff and bmark_name in diff[vm]:
                     mean_steady_cell = colour_html_cell(diff[vm][bmark_name][STEADY_STATE_TIME], mean_steady, 'right')
                     if diff[vm][bmark_name][STEADY_STATE_TIME_VAR] and diff[vm][bmark_name][STEADY_STATE_TIME_VAR] != 'SAME':
-                        var = '<div class="wrapper"><div class="tdcenter">%.6f</br><small>&plusmn;%.6f</small></div></div>' % \
+                        var = '<div class="wrapper"><div class="tdcenter">%.6f<br/><small>was: %.6f</small></div></div>' % \
                                    (bmark['steady_state_time_ci'],
-                                    abs(bmark['steady_state_time_ci'] - previous['machines'][machine][vm][bmark_name]['steady_state_time_ci']))
+                                    previous['machines'][machine][vm][bmark_name]['steady_state_time_ci'])
                         mean_steady_var_cell = colour_html_cell(diff[vm][bmark_name][STEADY_STATE_TIME_VAR], var, 'center')
                     else:
                         mean_steady_var_cell = '<td></td>'


### PR DESCRIPTION
In some cases we have CIs narrowing by 0.000012s which is hard to justify. This diff sets a minimum threshold of 0.001s as being considered significant (this deliberately mirrors the threshold used to determine if two changepoint segments are correct).

Tom: this is untested. Can you try it on (at least) the LuaJIT vs. counters HTML diff and see if it does the right thing? Thanks!