### PR TITLE
Add a --quality switch to warmup_stats.

### DIFF
--- a/bin/warmup_stats
+++ b/bin/warmup_stats
@@ -180,6 +180,9 @@ def create_arg_parser():
                               type=str, metavar='DIFF_FILENAME', default=None,
                               help='Output a file containing a diff table. Requires '
                               '--tex or --html. Expects exactly two input files.')
+    parser.add_argument('--quality', action='store', default='HIGH',
+                        dest='quality',
+                        help='Quality of statistics. [low|high]. Default: high.')
     return parser
 
 
@@ -445,7 +448,7 @@ def main(options):
         info('Collecting summary statistics.')
         input_files = [bm.krun_filename_changepoints for bm in benchmarks]
         classifier, data_dictionary = parse_krun_file_with_changepoints(input_files)
-        summary = collect_summary_statistics(data_dictionary, classifier['delta'], classifier['steady'])
+        summary = collect_summary_statistics(data_dictionary, classifier['delta'], classifier['steady'], quality=options.quality)
     if options.output_plots:
         info('Generating PDF plots.')
         input_files = [bm.krun_filename_changepoints for bm in benchmarks]

--- a/warmup/bootstrapper.py
+++ b/warmup/bootstrapper.py
@@ -40,11 +40,7 @@
 """
 This script is designed to be run with PyPy via a pipe.
 
-It has been factored out because the code here is too slow to run on CPython,
-and we need numpy as a dependency in related parts of the code base. Although
-there is a version of numpy for PyPy, we wanted to reduce the number of
-complications that arise for end-users.
-
+It has been factored out because the code here is too slow to run on CPython.
 It will read JSON format data from STDIN, and will write a comma-separated pair
 of floats (mean, CI) on STDOUT.
 

--- a/warmup/bootstrapper.py
+++ b/warmup/bootstrapper.py
@@ -55,13 +55,13 @@ segments, each containing a list of floats.
 Much of the code here comes from libkalibera.
 """
 
-import math
-import random
+import argparse, json, math, random, sys
 
 from decimal import Decimal, ROUND_UP, ROUND_DOWN
 
 
-BOOTSTRAP_ITERATIONS = 100000
+BOOTSTRAP_ITERATIONS_HIGHQ = 100000
+BOOTSTRAP_ITERATIONS_LOWQ = 10000
 CONFIDENCE_LEVEL = '0.99'  # Must be a string to pass to Decimal.
 
 
@@ -70,26 +70,27 @@ def _mean(data):
     return math.fsum(data) / float(len(data))
 
 
-def _bootstrap_means(steady_segments_all_pexecs):
+def _bootstrap_means_lowq(steady_segments_all_pexecs):
     # How many bootstrap samples do we need from each pexec? We want at least
     # BOOTSTRAP_ITERATIONS samples over all. If we want 100,000 samples in total
     # and we have 30 pexecs, we need 3333 samples from each pexec. In total we
     # will have 3333 * 30 bootstrapped samples, and 3333 * 30 == 99990. So, we
     # add a 1 here to ensure that we end up with >= BOOTSTRAP_ITERATIONS samples.
-    n_resamples = int(math.floor(BOOTSTRAP_ITERATIONS / len(steady_segments_all_pexecs))) + 1
+    n_resamples = int(math.floor(BOOTSTRAP_ITERATIONS_LOWQ / len(steady_segments_all_pexecs))) + 1
     means = list()  # Final list of BOOTSTRAP_ITERATIONS resamples.
 
     for segments in steady_segments_all_pexecs:  # Iterate over pexecs.
         for _ in xrange(n_resamples):
             num_samples = 0
 
-            # Note that summing into a float like this does cause rounding errors, but for 100,000
-            # bootstrap iterations that error is only apparent at the 9th decimal point, which is
-            # acceptable in our case. Roughly speaking, each factor of 10 bigger that
-            # BOOTSTRAP_ITERATIONS becomes, the error becomes 1 decimal place "worse",
-            # so if you ever crank BOOTSTRAP_ITERATIONS to a mammoth value, keep this in mind.
+            # Note that summing into a float like this does cause rounding
+            # errors, but for 10,000 bootstrap iterations and values in the
+            # 0.0-1.0 range, that error is only apparent at the 10th decimal
+            # place. However, the error increases as the bootstrap iterations
+            # and/or timings increase above: roughly speaking the error becomes
+            # 1 decimal place worse for each order of magnitude bigger the
+            # bootstrap iterations and/or timings become.
             sample_sum = 0.0
-
             for seg in segments:
                 seg_len = len(seg)
                 num_samples += seg_len
@@ -97,16 +98,40 @@ def _bootstrap_means(steady_segments_all_pexecs):
                     sample_sum += seg[int(random.random() * seg_len)]
 
             means.append(sample_sum / float(num_samples))
-    assert len(means) >= BOOTSTRAP_ITERATIONS
+    assert len(means) >= BOOTSTRAP_ITERATIONS_LOWQ
+    return means
+
+def _bootstrap_means_highq(steady_segments_all_pexecs):
+    # How many bootstrap samples do we need from each pexec? We want at least
+    # BOOTSTRAP_ITERATIONS samples over all. If we want 100,000 samples in total
+    # and we have 30 pexecs, we need 3333 samples from each pexec. In total we
+    # will have 3333 * 30 bootstrapped samples, and 3333 * 30 == 99990. So, we
+    # add a 1 here to ensure that we end up with >= BOOTSTRAP_ITERATIONS samples.
+    n_resamples = int(math.floor(BOOTSTRAP_ITERATIONS_HIGHQ / len(steady_segments_all_pexecs))) + 1
+    means = list()  # Final list of BOOTSTRAP_ITERATIONS resamples.
+
+    for segments in steady_segments_all_pexecs:  # Iterate over pexecs.
+        for _ in xrange(n_resamples):
+            sample = list()
+            for seg in segments:
+                sample.extend([random.choice(seg) for _ in xrange(len(seg))])
+            means.append(_mean(sample))
+    assert len(means) >= BOOTSTRAP_ITERATIONS_HIGHQ
     return means
 
 
-def bootstrap_steady_perf(steady_segments_all_pexecs, confidence_level=CONFIDENCE_LEVEL):
+def bootstrap_steady_perf(steady_segments_all_pexecs, confidence_level=CONFIDENCE_LEVEL, quality='HIGH'):
     """This is not a general bootstrapping function.
     Input is a list containing a list for each pexec, containing a list of
     segments with iteration times.
     """
-    means = _bootstrap_means(steady_segments_all_pexecs)
+    if quality.lower() == "high":
+        means = _bootstrap_means_highq(steady_segments_all_pexecs)
+    elif quality.lower() == "low":
+        means = _bootstrap_means_lowq(steady_segments_all_pexecs)
+    else:
+        sys.stderr.write("Unknown quality level '%s'" % quality)
+        sys.exit(1)
     means.sort()
 
     # Compute reported mean and confidence interval. Code below is from libkalibera.
@@ -129,9 +154,12 @@ def bootstrap_steady_perf(steady_segments_all_pexecs, confidence_level=CONFIDENC
 
 
 if __name__ == '__main__':
-    import json
-    import sys
+    parser = argparse.ArgumentParser(description='Bootstrap data.')
+    parser.add_argument('--quality', action='store', default='HIGH',
+                        dest='quality',
+                        help='Quality of statistics. Must be one of: LOW, HIGH.')
+    options = parser.parse_args()
     data = json.loads(sys.stdin.readline())
-    results = bootstrap_steady_perf(data)
+    results = bootstrap_steady_perf(data, quality=options.quality)
     sys.stdout.write(','.join([str(result) for result in results]))
     sys.stdout.flush()

--- a/warmup/statistics.py
+++ b/warmup/statistics.py
@@ -51,13 +51,14 @@ def median_iqr(seq):
     return numpy.median(seq), (numpy.percentile(seq, LOW_IQR_BOUND), numpy.percentile(seq, HIGH_IQR_BOUND))
 
 
-def bootstrap_runner(marshalled_data):
+def bootstrap_runner(marshalled_data, quality='HIGH'):
     """Input should be a JSON string, containing a list of pexecs, each
     containing a list of segments, each containing a list of floats.
     """
 
     try:
-        pipe = subprocess.Popen(['pypy', BOOTSTRAPPER], stdin=subprocess.PIPE,
+        pipe = subprocess.Popen(['pypy', BOOTSTRAPPER, '--quality', quality],
+                                stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE)
         pipe.stdin.write(marshalled_data + '\n')
         pipe.stdin.flush()

--- a/warmup/summary_statistics.py
+++ b/warmup/summary_statistics.py
@@ -72,7 +72,7 @@ SKIPPED_BEFORE = 0
 SKIPPED_AFTER = 1
 
 
-def collect_summary_statistics(data_dictionaries, delta, steady_state):
+def collect_summary_statistics(data_dictionaries, delta, steady_state, quality='HIGH'):
     """Create summary statistics of a dataset with classifications.
     Note that this function returns a dict which is consumed by other code to
     create tables. It also DEFINES the JSON format which the ../bin/warmup_stats
@@ -206,13 +206,13 @@ def collect_summary_statistics(data_dictionaries, delta, steady_state):
                 median_time_to_steady, error_time_to_steady = None, None
                 # Shell out to PyPy for speed.
                 marshalled_data = json.dumps(segments_for_bootstrap_all_pexecs)
-                mean_time, error_time = bootstrap_runner(marshalled_data)
+                mean_time, error_time = bootstrap_runner(marshalled_data, quality)
                 if mean_time is None or error_time is None:
                     raise ValueError()
             else:
                 # Shell out to PyPy for speed.
                 marshalled_data = json.dumps(segments_for_bootstrap_all_pexecs)
-                mean_time, error_time = bootstrap_runner(marshalled_data)
+                mean_time, error_time = bootstrap_runner(marshalled_data, quality)
                 if mean_time is None or error_time is None:
                     raise ValueError()
                 if steady_iters:


### PR DESCRIPTION
PR #97 showed that we can get meaningful performance changes in table generation if we're prepared to tolerate slightly lower quality stats. In that PR, I made a rough estimate of how inaccurate they might be. However, I neglected to consider that floating point numbers have a very uneven spread: 50% of FP numbers reside between 0 and 1. In other words, the error is going to increase as someone's benchmark timings increase, which is surprising.

This commit introduces a --quality option with two settings: "low" (and fast) and "high" (and slow). The default is "high". Relative to #97, "low" also reduces the bootstrapping iterations, as well as using less accurate floating point summing. Roughly speaking, "high" is about 3x slower than "low", but one can observe small changes (at the fifth decimal place onwards) in data between low and high. Most of the time this is probably OK, but for paper quality benchmarking, the slightly longer time is worth it for more accurate stats, particularly as "high" quality tends to be more stable across runs (whereas there can be minor differences between low quality runs, which can confuse users).

I'm attaching two tables (as a zip, because GitHub doesn't allow us to attach HTML... )built with high and low quality stats (based on the 1.5 run of the warmup experiment): the biggest change I can see is TruffleRuby/binarytree's mean changing from 2.61061 (high quality) to 2.61059 (low quality). [tables.zip](https://github.com/softdevteam/warmup_stats/files/3029480/tables.zip)

CC/@smarr
