### PR TITLE
Add --only-vms to help with splitting down large tables.

### DIFF
--- a/bin/table_classification_summaries_others
+++ b/bin/table_classification_summaries_others
@@ -69,6 +69,8 @@ def create_cli_parser():
     parser.add_argument('--without-preamble', action='store_true',
                         dest='without_preamble', default=False,
                         help='Write out only the table (for inclusion in a separate document).')
+    parser.add_argument('--only-vms', type=str,
+                        help='Exclude VMs not present in the provided comma-separated list')
     return parser
 
 
@@ -81,7 +83,12 @@ if __name__ == '__main__':
               'in order to compile correctly.')
     summary_data = collect_summary_statistics(data_dcts, classifier['delta'], classifier['steady'])
     machine, bmarks, latex_summary = convert_to_latex(summary_data, classifier['delta'], classifier['steady'])
+    if options.only_vms:
+        only_vms = options.only_vms.split(",")
+    else:
+        only_vms = None
+
     print('Writing data to: %s' % options.latex_file)
     write_latex_table(machine, bmarks, latex_summary, options.latex_file,
                       with_preamble=(not options.without_preamble),
-                      longtable=True)
+                      longtable=True, only_vms=only_vms)

--- a/warmup/summary_statistics.py
+++ b/warmup/summary_statistics.py
@@ -354,7 +354,7 @@ def convert_to_latex(summary_data, delta, steady_state, diff=None, previous=None
 
 
 def write_latex_table(machine, all_benchs, summary, tex_file, with_preamble=False,
-                      longtable=False):
+                      longtable=False, only_vms=None):
     """Write a tex table to disk.
     This is NOT used to create diff tables or the tables for the warmup
     experiment (a separate script in the other repo exists for that). However,
@@ -363,7 +363,10 @@ def write_latex_table(machine, all_benchs, summary, tex_file, with_preamble=Fals
     """
 
     num_benchmarks = len(all_benchs)
-    all_vms = sorted(summary.keys())
+    if only_vms is not None:
+        all_vms = sorted([vm for vm in summary.keys() if vm in only_vms])
+    else:
+        all_vms = sorted(summary.keys())
     num_vms = len(summary)
 
     with open(tex_file, 'w') as fp:


### PR DESCRIPTION
This change adds a flag which allows us to filter out tabulated results by VM. This will help us split down large tables into smaller per-vm ones for the renaissance paper.

Tested using v0.1 data.

Looks good?